### PR TITLE
Improved indentention and some fixes

### DIFF
--- a/juci/config.cc
+++ b/juci/config.cc
@@ -15,6 +15,9 @@ MainConfig::MainConfig() :
 void MainConfig::GenerateSource() {
   DEBUG("Fetching source cfg");
   boost::property_tree::ptree source_json = cfg_.get_child("source");
+  source_cfg_.tab_size=source_json.get<unsigned>("tab_size");
+  for(unsigned c=0;c<source_cfg_.tab_size;c++)
+    source_cfg_.tab+=" ";
   boost::property_tree::ptree syntax_json = source_json.get_child("syntax");
   boost::property_tree::ptree colors_json = source_json.get_child("colors");
   boost::property_tree::ptree extensions_json = source_json.get_child("extensions");

--- a/juci/config.json
+++ b/juci/config.json
@@ -28,7 +28,8 @@
 	    "hpp",
 	    "hxx",
 	    "h++"
-        ]
+        ],
+	"tab_size": 2
     },
     "keybindings": {
         "new_file": "<control>n",

--- a/juci/juci.cc
+++ b/juci/juci.cc
@@ -13,6 +13,7 @@ int main(int argc, char *argv[]) {
                                                                 argc,
                                                                 argv,
                                                                 "no.sout.juci");
+  Gsv::init();
   init_logging();
   Window window;
   return app->run(window);

--- a/juci/notebook.cc
+++ b/juci/notebook.cc
@@ -1,7 +1,6 @@
 #include <fstream>
 #include "notebook.h"
 #include "logging.h"
-#include <regex>
 
 Notebook::Model::Model() {
   cc_extension_ = ".cpp";
@@ -19,6 +18,7 @@ Notebook::Controller::Controller(Gtk::Window* window,
                                  Source::Config& source_cfg,
                                  Directories::Config& dir_cfg) :
   directories_(dir_cfg),
+  source_config_(source_cfg),
   index_(0, 1) {
   INFO("Create notebook");
   window_ = window;
@@ -26,7 +26,6 @@ Notebook::Controller::Controller(Gtk::Window* window,
   refClipboard_ = Gtk::Clipboard::get();
   ispopup = false;
   view().pack1(directories_.widget(), true, true);
-  source_config_ = source_cfg;
   CreateKeybindings(keybindings);
   INFO("Notebook Controller Success");
 }  // Constructor
@@ -183,77 +182,6 @@ bool Notebook::Controller:: OnMouseRelease(GdkEventButton* button) {
   if (button->button == 1 && ispopup) {
     popup_.response(Gtk::RESPONSE_DELETE_EVENT);
     return true;
-  }
-  return false;
-}
-
-bool Notebook::Controller::OnKeyPress(GdkEventKey* key) {
-  //Indent as in previous line, and indent left after if/else/etc
-  if(key->keyval==GDK_KEY_Return && key->state==0) {
-    Gtk::TextIter insert_it = Buffer(text_vec_.at(CurrentPage()))->get_insert()->get_iter();
-    Gtk::TextIter line_it = Buffer(text_vec_.at(CurrentPage()))->get_iter_at_line(insert_it.get_line());
-    std::string line(Buffer(text_vec_.at(CurrentPage()))->get_text(line_it, insert_it));
-    std::smatch sm;
-    const std::regex bracket_regex("^( *).*\\{ *$");
-    const std::regex no_bracket_statement_regex("^( *)(if|else|else if|try|catch|while)[^\\}]*$");
-    const std::regex no_bracket_regex("^( *).*$");
-    if(std::regex_match(line, sm, bracket_regex)) {
-      Buffer(text_vec_.at(CurrentPage()))->insert_at_cursor("\n"+sm[1].str()+"  ");
-    }
-    else if(std::regex_match(line, sm, no_bracket_statement_regex)) {
-      Buffer(text_vec_.at(CurrentPage()))->insert_at_cursor("\n"+sm[1].str()+"  ");
-    }
-    else if(std::regex_match(line, sm, no_bracket_regex)) {
-      Buffer(text_vec_.at(CurrentPage()))->insert_at_cursor("\n"+sm[1].str());
-    }
-    CurrentTextView().scroll_to(Buffer(text_vec_.at(CurrentPage()))->get_insert());
-    return true;
-  }
-  //Indent right when clicking tab, no matter where in the line the cursor is. Also works on selected text.
-  if(key->keyval==GDK_KEY_Tab && key->state==0) {
-    Gtk::TextIter selection_start, selection_end;
-    Buffer(text_vec_.at(CurrentPage()))->get_selection_bounds(selection_start, selection_end);
-    int line_start=selection_start.get_line();
-    int line_end=selection_end.get_line();
-    for(int line=line_start;line<=line_end;line++) {
-      Gtk::TextIter line_it = Buffer(text_vec_.at(CurrentPage()))->get_iter_at_line(line);
-      Buffer(text_vec_.at(CurrentPage()))->insert(line_it, "  ");
-    }
-    return true;
-  }
-  //Indent left when clicking shift-tab, no matter where in the line the cursor is. Also works on selected text.
-  else if((key->keyval==GDK_KEY_ISO_Left_Tab || key->keyval==GDK_KEY_Tab) && key->state==GDK_SHIFT_MASK) {
-    Gtk::TextIter selection_start, selection_end;
-    Buffer(text_vec_.at(CurrentPage()))->get_selection_bounds(selection_start, selection_end);
-    int line_start=selection_start.get_line();
-    int line_end=selection_end.get_line();
-    for(int line=line_start;line<=line_end;line++) {
-      Gtk::TextIter line_it = Buffer(text_vec_.at(CurrentPage()))->get_iter_at_line(line);
-      Gtk::TextIter line_plus_it=line_it;
-      line_plus_it++;
-      line_plus_it++;
-      std::string start(Buffer(text_vec_.at(CurrentPage()))->get_text(line_it, line_plus_it));
-      if(start=="  ")
-        Buffer(text_vec_.at(CurrentPage()))->erase(line_it, line_plus_it);
-    }
-    return true;
-  }
-  //Indent left when writing } on a new line
-  else if(key->keyval==GDK_KEY_braceright) {
-    Gtk::TextIter insert_it = Buffer(text_vec_.at(CurrentPage()))->get_insert()->get_iter();
-    Gtk::TextIter line_it = Buffer(text_vec_.at(CurrentPage()))->get_iter_at_line(insert_it.get_line());
-    Gtk::TextIter line_plus_it=line_it;
-    line_plus_it++;
-    line_plus_it++;
-    std::string start(Buffer(text_vec_.at(CurrentPage()))->get_text(line_it, line_plus_it));
-    std::string line(Buffer(text_vec_.at(CurrentPage()))->get_text(line_it, insert_it));
-    for(auto &c: line) {
-      if(c!=' ')
-        return false;
-    }
-    if(start=="  ")
-      Buffer(text_vec_.at(CurrentPage()))->erase(line_it, line_plus_it);
-    return false;
   }
   return false;
 }
@@ -570,9 +498,6 @@ void Notebook::Controller::BufferChangeHandler(Glib::RefPtr<Gtk::TextBuffer>
 void Notebook::Controller::TextViewHandlers(Gtk::TextView& textview) {
   textview.signal_button_release_event().
     connect(sigc::mem_fun(*this, &Notebook::Controller::OnMouseRelease), false);
-
-  textview.signal_key_press_event().
-    connect(sigc::mem_fun(*this, &Notebook::Controller::OnKeyPress), false);
 
   textview.signal_key_release_event().
     connect(sigc::mem_fun(*this, &Notebook::Controller::OnKeyRelease), false);

--- a/juci/notebook.h
+++ b/juci/notebook.h
@@ -35,7 +35,7 @@ namespace Notebook {
                Source::Config& config,
                Directories::Config& dir_cfg);
     ~Controller();
-    Glib::RefPtr<Gtk::TextBuffer> Buffer(Source::Controller *source);
+    Glib::RefPtr<Gtk::TextBuffer> Buffer(Source::Controller &source);
     Source::View& CurrentTextView();
     int CurrentPage();
     Gtk::Box& entry_view();
@@ -101,7 +101,7 @@ namespace Notebook {
     bool is_new_file_;
     Entry::Controller entry_;
 
-    std::vector<Source::Controller*> text_vec_;
+    std::vector<std::unique_ptr<Source::Controller> > text_vec_;
     std::vector<Gtk::ScrolledWindow*> scrolledtext_vec_;
     std::vector<Gtk::HBox*> editor_vec_;
     std::list<Gtk::TargetEntry> listTargets_;

--- a/juci/notebook.h
+++ b/juci/notebook.h
@@ -71,7 +71,6 @@ namespace Notebook {
     void Search(bool forward);
     Source::Config& source_config() { return source_config_; }
     bool OnMouseRelease(GdkEventButton* button);
-    bool OnKeyPress(GdkEventKey* key);
     bool OnKeyRelease(GdkEventKey* key);
     std::string OnSaveFileAs();
     bool LegalExtension(std::string extension);

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -435,15 +435,20 @@ bool Source::Controller::OnKeyPress(GdkEventKey* key) {
       size_t line_nr=buffer()->get_insert()->get_iter().get_line();
       if(line_nr>0 && sm[1].str().size()>=model().config().tab_size) {
         string previous_line=view().GetLine(line_nr-1);
-        if(std::regex_match(previous_line, sm2, no_bracket_statement_regex))
-          buffer()->insert_at_cursor("\n"+sm2[1].str());
-        else if(std::regex_match(previous_line, sm2, no_bracket_no_para_statement_regex))
-          buffer()->insert_at_cursor("\n"+sm2[1].str());
-        else
-          buffer()->insert_at_cursor("\n"+sm[1].str());
+        if(!std::regex_match(previous_line, sm2, bracket_regex)) {
+          if(std::regex_match(previous_line, sm2, no_bracket_statement_regex)) {
+            buffer()->insert_at_cursor("\n"+sm2[1].str());
+            view().scroll_to(buffer()->get_insert());
+            return true;
+          }
+          else if(std::regex_match(previous_line, sm2, no_bracket_no_para_statement_regex)) {
+            buffer()->insert_at_cursor("\n"+sm2[1].str());
+            view().scroll_to(buffer()->get_insert());
+            return true;
+          }
+        }
       }
-      else
-        buffer()->insert_at_cursor("\n"+sm[1].str());
+      buffer()->insert_at_cursor("\n"+sm[1].str());
       view().scroll_to(buffer()->get_insert());
     }
     return true;

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -433,7 +433,7 @@ bool Source::Controller::OnKeyPress(GdkEventKey* key) {
     else if(std::regex_match(line, sm, spaces_regex)) {
       std::smatch sm2;
       size_t line_nr=buffer()->get_insert()->get_iter().get_line();
-      if(line_nr>0 && sm[1].str().size()>=2) {
+      if(line_nr>0 && sm[1].str().size()>=model().config().tab_size) {
         string previous_line=view().GetLine(line_nr-1);
         if(std::regex_match(previous_line, sm2, no_bracket_statement_regex))
           buffer()->insert_at_cursor("\n"+sm2[1].str());

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -31,7 +31,7 @@ Source::View::View() {
   override_font(Pango::FontDescription("Monospace"));
   set_show_line_numbers(true);
   set_highlight_current_line(true);
-  set_smart_home_end(Gsv::SMART_HOME_END_ALWAYS);
+  set_smart_home_end(Gsv::SMART_HOME_END_BEFORE);
 }
 
 string Source::View::GetLine(const Gtk::TextIter &begin) {

--- a/juci/source.h
+++ b/juci/source.h
@@ -129,7 +129,7 @@ namespace Source {
     Config config_;
     std::string file_path_;
     std::string project_path_;
-    clang::TranslationUnit tu_;
+    std::unique_ptr<clang::TranslationUnit> tu_; //use unique_ptr since it is not initialized in constructor
     void HighlightToken(clang::Token *token,
                         std::vector<Range> *source_ranges,
                         int token_kind);

--- a/juci/source.h
+++ b/juci/source.h
@@ -143,6 +143,7 @@ namespace Source {
     Controller(const Source::Config &config,
                Notebook::Controller *notebook);
     Controller();
+    ~Controller();
     View& view();
     Model& model();
     void OnNewEmptyFile();

--- a/juci/source.h
+++ b/juci/source.h
@@ -17,8 +17,6 @@ namespace Notebook {
 namespace Source {
   class Config {
   public:
-    Config(const Config &original);
-    Config();
     const std::unordered_map<std::string, std::string>& tagtable() const;
     const std::unordered_map<std::string, std::string>& typetable() const;
      std::vector<std::string>& extensiontable();
@@ -30,6 +28,8 @@ namespace Source {
     void InsertType(const std::string &key, const std::string &value);
     void InsertExtension(const std::string &ext);
         std::vector<std::string> extensiontable_;
+    unsigned tab_size; //TODO: Have to clean away all the simple setter and getter methods at some point. It creates too much unnecessary code
+    std::string tab;
   private:
     std::unordered_map<std::string, std::string> tagtable_;
     std::unordered_map<std::string, std::string> typetable_;
@@ -70,9 +70,8 @@ namespace Source {
                     const Config &config);
     void OnUpdateSyntax(const std::vector<Range> &locations,
                         const Config &config);
-
-  private:
-    std::string GetLine(const Gtk::TextIter &begin);
+    std::string GetLine(size_t line_number);
+    std::string GetLineBeforeInsert();
   };  // class View
 
   class AutoCompleteChunk {
@@ -159,6 +158,7 @@ namespace Source {
     void set_is_saved(bool isSaved) { is_saved_ = isSaved; }
     void set_is_changed(bool isChanged) { is_changed_ = isChanged; }
     void set_file_path(std::string path) { model().set_file_path(path); }
+    bool OnKeyPress(GdkEventKey* key);
 
   private:
     void OnLineEdit();

--- a/juci/terminal.cc
+++ b/juci/terminal.cc
@@ -47,7 +47,7 @@ void Terminal::Controller::Compile(){
   Terminal().get_buffer()->set_text("");
   DEBUG("Terminal: Compile: running cmake command");
   std::vector<std::string> commands = config().compile_commands();
-  for (auto it = 0; it < commands.size(); ++it) {
+  for (size_t it = 0; it < commands.size(); ++it) {
     ExecuteCommand(commands.at(it), "r");
     
   }


### PR DESCRIPTION
There are alot of really simple getters and setters, these should be removed at some point. Direct access to class members should be allowed, and this will result in smaller and simpler code. Bjarne Stroustrup agrees with this btw:)

Some cleanup should also be done with respect to model, view, controller as well. Not entirely sure how best to do this yet however. I could try to clean up source.h and source.cc maybe, and we could use this as a base for the rest of the classes. This would include getting rid of the simple getter and setter methods in these classes (source.h). 

I will also try to find the reason behind the segmentation fault when you open/close tabs several times. 