### PR TITLE
Diagnostics on the fly

### DIFF
--- a/juci/CMakeLists.txt
+++ b/juci/CMakeLists.txt
@@ -125,6 +125,8 @@ add_executable(${project_name}
   directories.cc
   terminal.h
   terminal.cc
+  tooltips.h
+  tooltips.cc
   )
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)

--- a/juci/CMakeLists.txt
+++ b/juci/CMakeLists.txt
@@ -127,6 +127,8 @@ add_executable(${project_name}
   terminal.cc
   tooltips.h
   tooltips.cc
+  singletons.h
+  singletons.cc
   )
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)

--- a/juci/config.cc
+++ b/juci/config.cc
@@ -2,7 +2,7 @@
 #include "logging.h"
 
 MainConfig::MainConfig() :
-  keybindings_cfg(), source_cfg() {
+  keybindings_cfg() {
   INFO("Reading config file");
   boost::property_tree::json_parser::read_json("config.json", cfg_);
   INFO("Config file read");
@@ -13,6 +13,7 @@ MainConfig::MainConfig() :
 }
 
 void MainConfig::GenerateSource() {
+  auto source_cfg=Singletons::Config::source();
   DEBUG("Fetching source cfg");
   // boost::property_tree::ptree
   auto source_json = cfg_.get_child("source");
@@ -22,30 +23,33 @@ void MainConfig::GenerateSource() {
   auto visual_json = source_json.get_child("visual");
   for (auto &i : visual_json) {
     if (i.first == "background") {
-	     source_cfg.background = i.second.get_value<std::string>();
+	     source_cfg->background = i.second.get_value<std::string>();
+    }
+    if (i.first == "background_tooltips") {
+	     source_cfg->background_tooltips = i.second.get_value<std::string>();
     }
     if (i.first == "show_line_numbers") {
-      source_cfg.show_line_numbers = i.second.get_value<std::string>() == "1" ? true : false;
+      source_cfg->show_line_numbers = i.second.get_value<std::string>() == "1" ? true : false;
     }
     if (i.first == "highlight_current_line") {
-      source_cfg.highlight_current_line = i.second.get_value<std::string>() == "1" ? true : false;
+      source_cfg->highlight_current_line = i.second.get_value<std::string>() == "1" ? true : false;
     }
     if (i.first == "font") {
-      source_cfg.font = i.second.get_value<std::string>();
+      source_cfg->font = i.second.get_value<std::string>();
     }
   }
-  source_cfg.tab_size = source_json.get<unsigned>("tab_size");
-  for (unsigned c = 0; c < source_cfg.tab_size; c++) {
-    source_cfg.tab+=" ";
+  source_cfg->tab_size = source_json.get<unsigned>("tab_size");
+  for (unsigned c = 0; c < source_cfg->tab_size; c++) {
+    source_cfg->tab+=" ";
   }
   for (auto &i : colors_json) {
-    source_cfg.tags[i.first]=i.second.get_value<std::string>();
+    source_cfg->tags[i.first]=i.second.get_value<std::string>();
   }
   for (auto &i : syntax_json) {
-    source_cfg.types[i.first]=i.second.get_value<std::string>();
+    source_cfg->types[i.first]=i.second.get_value<std::string>();
   }
   for (auto &i : extensions_json) {
-    source_cfg.extensions.emplace_back(i.second.get_value<std::string>());
+    source_cfg->extensions.emplace_back(i.second.get_value<std::string>());
   }
   DEBUG("Source cfg fetched");
 }

--- a/juci/config.cc
+++ b/juci/config.cc
@@ -25,16 +25,19 @@ void MainConfig::GenerateSource() {
     if (i.first == "background") {
 	     source_cfg->background = i.second.get_value<std::string>();
     }
-    if (i.first == "background_tooltips") {
+    else if (i.first == "background_selected") {
+       source_cfg->background_selected = i.second.get_value<std::string>();
+    }
+    else if (i.first == "background_tooltips") {
 	     source_cfg->background_tooltips = i.second.get_value<std::string>();
     }
-    if (i.first == "show_line_numbers") {
+    else if (i.first == "show_line_numbers") {
       source_cfg->show_line_numbers = i.second.get_value<std::string>() == "1" ? true : false;
     }
-    if (i.first == "highlight_current_line") {
+    else if (i.first == "highlight_current_line") {
       source_cfg->highlight_current_line = i.second.get_value<std::string>() == "1" ? true : false;
     }
-    if (i.first == "font") {
+    else if (i.first == "font") {
       source_cfg->font = i.second.get_value<std::string>();
     }
   }

--- a/juci/config.h
+++ b/juci/config.h
@@ -4,6 +4,7 @@
 #include <boost/property_tree/xml_parser.hpp>
 #include <fstream>
 #include <string>
+#include "singletons.h"
 #include "keybindings.h"
 #include "source.h"
 #include "directories.h"
@@ -11,7 +12,6 @@
 
 class MainConfig {
 public:
-  Source::Config source_cfg;
   Terminal::Config terminal_cfg;
   Keybindings::Config keybindings_cfg;
   Directories::Config dir_cfg;

--- a/juci/config.json
+++ b/juci/config.json
@@ -34,6 +34,7 @@
         ],
         "visual": {
             "background": "white",
+            "background_tooltips": "yellow",
             "font": "Monospace",
             "show_line_numbers": 1,
             "highlight_current_line": 1

--- a/juci/config.json
+++ b/juci/config.json
@@ -34,6 +34,7 @@
         ],
         "visual": {
             "background": "white",
+            "background_selected": "blue",
             "background_tooltips": "yellow",
             "font": "Monospace",
             "show_line_numbers": 1,

--- a/juci/config.json
+++ b/juci/config.json
@@ -8,7 +8,9 @@
             "type": "#0066FF",
             "keyword": "blue",
             "comment": "grey",
-            "own": "pink"
+            "own": "pink",
+            "diagnostic_warning": "orange",
+            "diagnostic_error": "red"
         },
         "syntax": {
             "43": "type",

--- a/juci/notebook.cc
+++ b/juci/notebook.cc
@@ -187,6 +187,7 @@ void Notebook::Controller::OnOpenFile(std::string path) {
   Notebook().set_current_page(Pages()-1);
   Notebook().set_focus_child(*text_vec_.back()->view);
   //Add star on tab label when the page is not saved:
+  //TODO: instead use Gtk::TextBuffer::set_modified and Gtk::TextBuffer::get_modified
   text_vec_.back()->buffer()->signal_changed().connect([this]() {
     if(text_vec_.at(CurrentPage())->is_saved) {
       std::string path=CurrentTextView().file_path;

--- a/juci/notebook.cc
+++ b/juci/notebook.cc
@@ -11,11 +11,9 @@ Notebook::View::View() {
 
 Notebook::Controller::Controller(Keybindings::Controller& keybindings,
                                  Terminal::Controller& terminal,
-                                 Source::Config& source_cfg,
                                  Directories::Config& dir_cfg) :
   terminal(terminal),
-  directories(dir_cfg),
-  source_config(source_cfg) {
+  directories(dir_cfg) {
   INFO("Create notebook");
   refClipboard_ = Gtk::Clipboard::get();
   view.pack1(directories.widget(), true, true);
@@ -173,7 +171,7 @@ Notebook::Controller::~Controller() {
 void Notebook::Controller::OnOpenFile(std::string path) {
   INFO("Notebook open file");
   INFO("Notebook create page");
-  text_vec_.emplace_back(new Source::Controller(source_config, path, project_path, terminal));
+  text_vec_.emplace_back(new Source::Controller(path, project_path, terminal));
   scrolledtext_vec_.push_back(new Gtk::ScrolledWindow());
   editor_vec_.push_back(new Gtk::HBox());
   scrolledtext_vec_.back()->add(*text_vec_.back()->view);

--- a/juci/notebook.h
+++ b/juci/notebook.h
@@ -24,7 +24,6 @@ namespace Notebook {
   public:
     Controller(Keybindings::Controller& keybindings,
                Terminal::Controller& terminal,
-               Source::Config& config,
                Directories::Config& dir_cfg);
     ~Controller();
     Source::View& CurrentTextView();
@@ -51,7 +50,6 @@ namespace Notebook {
     Glib::RefPtr<Gtk::Builder> m_refBuilder;
     Glib::RefPtr<Gio::SimpleActionGroup> refActionGroup;
     Terminal::Controller& terminal;
-    Source::Config& source_config;
 
     std::vector<Gtk::ScrolledWindow*> scrolledtext_vec_;
     std::vector<Gtk::HBox*> editor_vec_;

--- a/juci/selectiondialog.cc
+++ b/juci/selectiondialog.cc
@@ -2,6 +2,8 @@
 
 SelectionDialog::SelectionDialog(Gtk::TextView& text_view): Gtk::Dialog(), text_view(text_view), 
       list_view_text(1, false, Gtk::SelectionMode::SELECTION_SINGLE) {
+  property_decorated()=false;
+  set_skip_taskbar_hint(true);
   scrolled_window.set_policy(Gtk::PolicyType::POLICY_NEVER, Gtk::PolicyType::POLICY_NEVER);
   list_view_text.set_enable_search(true);
   list_view_text.set_headers_visible(false);

--- a/juci/selectiondialog.cc
+++ b/juci/selectiondialog.cc
@@ -58,6 +58,7 @@ void SelectionDialog::show() {
   
   window->show_all();
   shown=true;
+  selected=false;
 }
 
 void SelectionDialog::hide() {
@@ -66,6 +67,7 @@ void SelectionDialog::hide() {
 }
 
 void SelectionDialog::select(bool hide_window) {
+  selected=true;
   auto selected=list_view_text->get_selected();
   std::string select;
   if(selected.size()>0) {
@@ -111,17 +113,19 @@ bool SelectionDialog::on_key_release(GdkEventKey* key) {
 }
 
 bool SelectionDialog::on_key_press(GdkEventKey* key) {
-  if(key->keyval>=GDK_KEY_0 && key->keyval<=GDK_KEY_9)
+  if((key->keyval>=GDK_KEY_0 && key->keyval<=GDK_KEY_9) || 
+     (key->keyval>=GDK_KEY_A && key->keyval<=GDK_KEY_Z) ||
+     (key->keyval>=GDK_KEY_a && key->keyval<=GDK_KEY_z) ||
+     key->keyval==GDK_KEY_underscore || key->keyval==GDK_KEY_BackSpace) {
+    if(selected) {
+      text_view.get_buffer()->erase(start_mark->get_iter(), text_view.get_buffer()->get_insert()->get_iter());
+      selected=false;
+      if(key->keyval==GDK_KEY_BackSpace)
+        return true;
+    }
     return false;
-  if(key->keyval>=GDK_KEY_A && key->keyval<=GDK_KEY_Z)
-    return false;
-  if(key->keyval>=GDK_KEY_a && key->keyval<=GDK_KEY_z)
-    return false;
+  }
   if(key->keyval==GDK_KEY_Shift_L || key->keyval==GDK_KEY_Shift_R || key->keyval==GDK_KEY_Alt_L || key->keyval==GDK_KEY_Alt_R || key->keyval==GDK_KEY_Control_L || key->keyval==GDK_KEY_Control_R || key->keyval==GDK_KEY_Meta_L || key->keyval==GDK_KEY_Meta_R)
-    return false;
-  if(key->keyval==GDK_KEY_underscore)
-    return false;
-  if(key->keyval==GDK_KEY_BackSpace)
     return false;
   if(key->keyval==GDK_KEY_Down) {
     auto it=list_view_text->get_selection()->get_selected();
@@ -147,11 +151,7 @@ bool SelectionDialog::on_key_press(GdkEventKey* key) {
     select(false);
     return true;
   }
-  if(key->keyval==GDK_KEY_Return) {
-    select();
-    return true;
-  }
-  if(key->keyval==GDK_KEY_ISO_Left_Tab || key->keyval==GDK_KEY_Tab) {
+  if(key->keyval==GDK_KEY_Return || key->keyval==GDK_KEY_ISO_Left_Tab || key->keyval==GDK_KEY_Tab) {
     select();
     return true;
   }

--- a/juci/selectiondialog.cc
+++ b/juci/selectiondialog.cc
@@ -1,9 +1,6 @@
 #include "selectiondialog.h"
-#include <regex>
 
-SelectionDialog::SelectionDialog(Gtk::TextView& text_view): text_view(text_view) {
-  
-}
+SelectionDialog::SelectionDialog(Gtk::TextView& text_view): text_view(text_view) {}
 
 void SelectionDialog::show() {
   if(rows.size()==0)

--- a/juci/selectiondialog.cc
+++ b/juci/selectiondialog.cc
@@ -1,87 +1,180 @@
 #include "selectiondialog.h"
+#include <iostream>
+using namespace std;
 
-SelectionDialog::SelectionDialog(Gtk::TextView& text_view): Gtk::Dialog(), text_view(text_view), 
-      list_view_text(1, false, Gtk::SelectionMode::SELECTION_SINGLE) {
-  property_decorated()=false;
-  set_skip_taskbar_hint(true);
-  scrolled_window.set_policy(Gtk::PolicyType::POLICY_NEVER, Gtk::PolicyType::POLICY_NEVER);
-  list_view_text.set_enable_search(true);
-  list_view_text.set_headers_visible(false);
-  list_view_text.set_hscroll_policy(Gtk::ScrollablePolicy::SCROLL_NATURAL);
-  list_view_text.set_activate_on_single_click(true);
+SelectionDialog::SelectionDialog(Gtk::TextView& text_view): text_view(text_view) {
+  
 }
 
-void SelectionDialog::show(const std::map<std::string, std::string>& rows) {
-  for (auto &i : rows) {
-    list_view_text.append(i.first);
-  }
-  scrolled_window.add(list_view_text);
-  get_vbox()->pack_start(scrolled_window);
-  set_transient_for((Gtk::Window&)(*text_view.get_toplevel()));
-  show_all();
-  int popup_x = get_width();
-  int popup_y = rows.size() * 20;
-  adjust(popup_x, popup_y);
+void SelectionDialog::show() {
+  if(rows.size()==0)
+    return;
   
-  list_view_text.signal_row_activated().connect([this](const Gtk::TreeModel::Path& path, Gtk::TreeViewColumn*) {
-    if(on_select)
-      on_select(list_view_text);
-    response(Gtk::RESPONSE_DELETE_EVENT);
+  window=std::unique_ptr<Gtk::Window>(new Gtk::Window(Gtk::WindowType::WINDOW_POPUP));
+  scrolled_window=std::unique_ptr<Gtk::ScrolledWindow>(new Gtk::ScrolledWindow());
+  list_view_text=std::unique_ptr<Gtk::ListViewText>(new Gtk::ListViewText(1, false, Gtk::SelectionMode::SELECTION_SINGLE));
+  
+  window->set_default_size(0, 0);
+  window->property_decorated()=false;
+  window->set_skip_taskbar_hint(true);
+  scrolled_window->set_policy(Gtk::PolicyType::POLICY_AUTOMATIC, Gtk::PolicyType::POLICY_AUTOMATIC);
+  list_view_text->set_enable_search(true);
+  list_view_text->set_headers_visible(false);
+  list_view_text->set_hscroll_policy(Gtk::ScrollablePolicy::SCROLL_NATURAL);
+  list_view_text->set_activate_on_single_click(true);
+  list_view_text->set_search_entry(search_entry);
+  list_view_text->set_hover_selection(true);
+  list_view_text->set_rules_hint(true);
+  //list_view_text->set_fixed_height_mode(true); //TODO: This is buggy on OS X, remember to post an issue on GTK+ 3
+
+  list_view_text->signal_row_activated().connect([this](const Gtk::TreeModel::Path& path, Gtk::TreeViewColumn*) {
+    if(shown) {
+      select();
+    }
+  });
+  list_view_text->signal_realize().connect([this](){
+    resize();
   });
   
-  signal_focus_out_event().connect(sigc::mem_fun(*this, &SelectionDialog::close), false);
-  
-  run();
-}
-
-bool SelectionDialog::close(GdkEventFocus*) {
-  response(Gtk::RESPONSE_DELETE_EVENT);
-  return true;
-}
-
-void SelectionDialog::adjust(int current_x, int current_y) {
-  INFO("SelectionDialog set size");
-  int view_x = text_view.get_width();
-  int view_y = 150;
-  bool is_never_scroll_x = true;
-  bool is_never_scroll_y = true;
-  if (current_x > view_x) {
-    current_x = view_x;
-    is_never_scroll_x = false;
-  }
-  if (current_y > view_y) {
-    current_y = view_y;
-    is_never_scroll_y = false;
-  }
-  scrolled_window.set_size_request(current_x, current_y);
-  if (!is_never_scroll_x && !is_never_scroll_y) {
-    scrolled_window.set_policy(Gtk::PolicyType::POLICY_AUTOMATIC, Gtk::PolicyType::POLICY_AUTOMATIC);
-  } else if (!is_never_scroll_x && is_never_scroll_y) {
-    scrolled_window.set_policy(Gtk::PolicyType::POLICY_AUTOMATIC, Gtk::PolicyType::POLICY_NEVER);
-  } else if (is_never_scroll_x && !is_never_scroll_y) {
-    scrolled_window.set_policy(Gtk::PolicyType::POLICY_NEVER, Gtk::PolicyType::POLICY_AUTOMATIC);
+  if(start_mark)
+    text_view.get_buffer()->delete_mark(start_mark);
+  start_mark=text_view.get_buffer()->create_mark(text_view.get_buffer()->get_insert()->get_iter());
+  start_offset=start_mark->get_iter().get_offset();
+  list_view_text->clear_items();
+  for (auto &i : rows) {
+    list_view_text->append(i.first);
   }
   
+  scrolled_window->add(*list_view_text);
+  window->add(*scrolled_window);
+    
+  if(rows.size()>0) {
+    list_view_text->get_selection()->select(*list_view_text->get_model()->children().begin());
+    list_view_text->scroll_to_row(list_view_text->get_selection()->get_selected_rows()[0]);
+  }
+    
+  move();
+  
+  window->show_all();
+  shown=true;
+}
+
+void SelectionDialog::hide() {
+  window->hide();
+  shown=false;
+}
+
+void SelectionDialog::select(bool hide_window) {
+  auto selected=list_view_text->get_selected();
+  if(selected.size()>0) {
+    std::string select = rows.at(list_view_text->get_text(selected[0]));
+    text_view.get_buffer()->erase(start_mark->get_iter(), text_view.get_buffer()->get_insert()->get_iter());
+    text_view.get_buffer()->insert(start_mark->get_iter(), select);
+  }
+  if(hide_window) {
+    hide();
+  }
+}
+
+bool SelectionDialog::on_key_release(GdkEventKey* key) {
+  if(key->keyval==GDK_KEY_Down || key->keyval==GDK_KEY_Up)
+    return false;
+    
+  if(start_offset>text_view.get_buffer()->get_insert()->get_iter().get_offset()) {
+    hide();
+  }
+  else {
+    auto text=text_view.get_buffer()->get_text(start_mark->get_iter(), text_view.get_buffer()->get_insert()->get_iter());
+    if(text.size()>0) {
+      search_entry.set_text(text);
+      list_view_text->set_search_entry(search_entry);
+    }
+  }
+  
+  return false;
+}
+
+bool SelectionDialog::on_key_press(GdkEventKey* key) {
+  if(key->keyval>=GDK_KEY_0 && key->keyval<=GDK_KEY_9)
+    return false;
+  if(key->keyval>=GDK_KEY_A && key->keyval<=GDK_KEY_Z)
+    return false;
+  if(key->keyval>=GDK_KEY_a && key->keyval<=GDK_KEY_z)
+    return false;
+  if(key->keyval==GDK_KEY_Shift_L || key->keyval==GDK_KEY_Shift_R || key->keyval==GDK_KEY_Alt_L || key->keyval==GDK_KEY_Alt_R || key->keyval==GDK_KEY_Control_L || key->keyval==GDK_KEY_Control_R || key->keyval==GDK_KEY_Meta_L || key->keyval==GDK_KEY_Meta_R)
+    return false;
+  if(key->keyval==GDK_KEY_underscore)
+    return false;
+  if(key->keyval==GDK_KEY_BackSpace)
+    return false;
+  if(key->keyval==GDK_KEY_Down) {
+    auto it=list_view_text->get_selection()->get_selected();
+    if(it) {
+      it++;
+      if(it) {
+        list_view_text->get_selection()->select(it);
+        list_view_text->scroll_to_row(list_view_text->get_selection()->get_selected_rows()[0]);
+      }
+    }
+    select(false);
+    return true;
+  }
+  if(key->keyval==GDK_KEY_Up) {
+    auto it=list_view_text->get_selection()->get_selected();
+    if(it) {
+      it--;
+      if(it) {
+        list_view_text->get_selection()->select(it);
+        list_view_text->scroll_to_row(list_view_text->get_selection()->get_selected_rows()[0]);
+      }
+    }
+    select(false);
+    return true;
+  }
+  if(key->keyval==GDK_KEY_Return) {
+    select();
+    return true;
+  }
+  if(key->keyval==GDK_KEY_ISO_Left_Tab || key->keyval==GDK_KEY_Tab) {
+    select();
+    return true;
+  }
+  hide();
+  return false;
+}
+
+void SelectionDialog::move() {
   INFO("SelectionDialog set position");
-  Gdk::Rectangle temp1, temp2;
-  text_view.get_cursor_locations(text_view.get_buffer()->get_insert()->get_iter(), temp1, temp2);
-  int view_edge_x = 0;
-  int view_edge_y = 0;
-  int x, y;
-  text_view.buffer_to_window_coords(Gtk::TextWindowType::TEXT_WINDOW_WIDGET, 
-                               temp1.get_x(), temp1.get_y(), x, y);
-  Glib::RefPtr<Gdk::Window> gdkw = text_view.get_window(Gtk::TextWindowType::TEXT_WINDOW_WIDGET);
-  gdkw->get_origin(view_edge_x, view_edge_y);
+  Gdk::Rectangle rectangle;
+  text_view.get_iter_location(start_mark->get_iter(), rectangle);
+  int buffer_x=rectangle.get_x();
+  int buffer_y=rectangle.get_y()+rectangle.get_height();
+  int window_x, window_y;
+  text_view.buffer_to_window_coords(Gtk::TextWindowType::TEXT_WINDOW_TEXT, buffer_x, buffer_y, window_x, window_y);
+  int root_x, root_y;
+  text_view.get_window(Gtk::TextWindowType::TEXT_WINDOW_TEXT)->get_root_coords(window_x, window_y, root_x, root_y);
+  window->move(root_x, root_y+1); //TODO: replace 1 with some margin
+}
 
-  x += view_edge_x;
-  y += view_edge_y;
-  if ((view_edge_x-x)*-1 > text_view.get_width()-current_x) {
-    x -= current_x;
-    if (x < view_edge_x) x = view_edge_x;
+void SelectionDialog::resize() {
+  INFO("SelectionDialog set size");
+  
+  if(list_view_text->get_realized()) {
+    int row_width=0, row_height;
+    Gdk::Rectangle rect;
+    list_view_text->get_cell_area(list_view_text->get_model()->get_path(list_view_text->get_model()->children().begin()), *(list_view_text->get_column(0)), rect);
+    row_width=rect.get_width();
+    row_height=rect.get_height();
+
+    row_width+=rect.get_x()*2; //TODO: Add correct margin x and y
+    row_height+=rect.get_y()*2;
+
+    if(row_width>text_view.get_width()/2)
+      row_width=text_view.get_width()/2;
+    else
+      scrolled_window->set_policy(Gtk::PolicyType::POLICY_NEVER, Gtk::PolicyType::POLICY_AUTOMATIC);
+
+    int window_height=std::min(row_height*(int)rows.size(), row_height*10);
+    window->resize(row_width, window_height);
   }
-  if ((view_edge_y-y)*-1 > text_view.get_height()-current_y) {
-    y -= (current_y+14) + 15;
-    if (x < view_edge_y) y = view_edge_y +15;
-  }
-  move(x, y+15);
 }

--- a/juci/selectiondialog.cc
+++ b/juci/selectiondialog.cc
@@ -1,4 +1,5 @@
 #include "selectiondialog.h"
+#include <regex>
 #include <iostream>
 using namespace std;
 
@@ -66,13 +67,28 @@ void SelectionDialog::hide() {
 
 void SelectionDialog::select(bool hide_window) {
   auto selected=list_view_text->get_selected();
+  std::string select;
   if(selected.size()>0) {
-    std::string select = rows.at(list_view_text->get_text(selected[0]));
+    select = rows.at(list_view_text->get_text(selected[0]));
     text_view.get_buffer()->erase(start_mark->get_iter(), text_view.get_buffer()->get_insert()->get_iter());
     text_view.get_buffer()->insert(start_mark->get_iter(), select);
   }
   if(hide_window) {
     hide();
+    char find_char=select.back();
+    if(find_char==')' || find_char=='>') {
+      if(find_char==')')
+        find_char='(';
+      else
+        find_char='<';
+      size_t pos=select.find(find_char);
+      if(pos!=std::string::npos) {
+        auto start_offset=start_mark->get_iter().get_offset()+pos+1;
+        auto end_offset=start_mark->get_iter().get_offset()+select.size()-1;
+        if(start_offset!=end_offset)
+          text_view.get_buffer()->select_range(text_view.get_buffer()->get_iter_at_offset(start_offset), text_view.get_buffer()->get_iter_at_offset(end_offset));
+      }
+    }
   }
 }
 

--- a/juci/selectiondialog.cc
+++ b/juci/selectiondialog.cc
@@ -11,7 +11,7 @@ void SelectionDialog::show() {
   
   window=std::unique_ptr<Gtk::Window>(new Gtk::Window(Gtk::WindowType::WINDOW_POPUP));
   scrolled_window=std::unique_ptr<Gtk::ScrolledWindow>(new Gtk::ScrolledWindow());
-  list_view_text=std::unique_ptr<Gtk::ListViewText>(new Gtk::ListViewText(1, false, Gtk::SelectionMode::SELECTION_SINGLE));
+  list_view_text=std::unique_ptr<Gtk::ListViewText>(new Gtk::ListViewText(1, false, Gtk::SelectionMode::SELECTION_BROWSE));
   
   window->set_default_size(0, 0);
   window->property_decorated()=false;
@@ -22,7 +22,7 @@ void SelectionDialog::show() {
   list_view_text->set_hscroll_policy(Gtk::ScrollablePolicy::SCROLL_NATURAL);
   list_view_text->set_activate_on_single_click(true);
   list_view_text->set_search_entry(search_entry);
-  list_view_text->set_hover_selection(true);
+  list_view_text->set_hover_selection(false);
   list_view_text->set_rules_hint(true);
   //list_view_text->set_fixed_height_mode(true); //TODO: This is buggy on OS X, remember to post an issue on GTK+ 3
 
@@ -108,7 +108,6 @@ bool SelectionDialog::on_key_release(GdkEventKey* key) {
     auto text=text_view.get_buffer()->get_text(start_mark->get_iter(), text_view.get_buffer()->get_insert()->get_iter());
     if(text.size()>0) {
       search_entry.set_text(text);
-      list_view_text->set_search_entry(search_entry);
     }
   }
   
@@ -173,7 +172,7 @@ void SelectionDialog::cursor_changed() {
     if(select.second.size()>0) {
       tooltips=std::unique_ptr<Tooltips>(new Tooltips());
       auto tooltip_text=select.second;
-      auto get_tooltip_buffer=[this, tooltip_text]() {        
+      auto get_tooltip_buffer=[this, tooltip_text]() {
         auto tooltip_buffer=Gtk::TextBuffer::create(text_view.get_buffer()->get_tag_table());
         //TODO: Insert newlines to tooltip_text (use 80 chars, then newline?)
         tooltip_buffer->insert_at_cursor(tooltip_text);

--- a/juci/selectiondialog.cc
+++ b/juci/selectiondialog.cc
@@ -34,7 +34,7 @@ void SelectionDialog::show() {
     resize();
   });
   
-  start_offset=start_mark->get_iter().get_offset();
+  show_offset=text_view.get_buffer()->get_insert()->get_iter().get_offset();
   list_view_text->clear_items();
   for (auto &i : rows) {
     list_view_text->append(i.first);
@@ -99,7 +99,7 @@ bool SelectionDialog::on_key_release(GdkEventKey* key) {
   if(key->keyval==GDK_KEY_Down || key->keyval==GDK_KEY_Up)
     return false;
     
-  if(start_offset>text_view.get_buffer()->get_insert()->get_iter().get_offset()) {
+  if(show_offset>text_view.get_buffer()->get_insert()->get_iter().get_offset()) {
     hide();
   }
   else {

--- a/juci/selectiondialog.h
+++ b/juci/selectiondialog.h
@@ -24,7 +24,7 @@ private:
   void cursor_changed();
   
   Gtk::Entry search_entry;
-  int start_offset;
+  int show_offset;
   bool row_in_entry;
   
   Gtk::TextView& text_view;

--- a/juci/selectiondialog.h
+++ b/juci/selectiondialog.h
@@ -16,23 +16,23 @@ public:
   bool on_key_press(GdkEventKey* key);
   
   std::map<std::string, std::pair<std::string, std::string> > rows;
-
   bool shown=false;
+  Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark;
 private:
   void resize();
   void select(bool hide_window=true);
   void cursor_changed();
   
   Gtk::Entry search_entry;
-  Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark;
   int start_offset;
-  bool selected;
+  bool row_in_entry;
   
   Gtk::TextView& text_view;
   std::unique_ptr<Gtk::Window> window;
   std::unique_ptr<Gtk::ScrolledWindow> scrolled_window;
   std::unique_ptr<Gtk::ListViewText> list_view_text;
   std::unique_ptr<Tooltips> tooltips;
+  int last_selected;
 };
 
 #endif  // JUCI_SELECTIONDIALOG_H_

--- a/juci/selectiondialog.h
+++ b/juci/selectiondialog.h
@@ -10,7 +10,6 @@ public:
   void show();
   void hide();
   bool close(GdkEventFocus*);
-  void select(bool hide_window=true);
   void move();
   bool on_key_release(GdkEventKey* key);
   bool on_key_press(GdkEventKey* key);
@@ -18,11 +17,14 @@ public:
   std::map<std::string, std::string> rows;
 
   bool shown=false;
+private:
+  void resize();
+    void select(bool hide_window=true);
+  
   Gtk::Entry search_entry;
   Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark;
   int start_offset;
-private:
-  void resize();
+  bool selected;
   
   Gtk::TextView& text_view;
   std::unique_ptr<Gtk::Window> window;

--- a/juci/selectiondialog.h
+++ b/juci/selectiondialog.h
@@ -3,22 +3,31 @@
 
 #include "gtkmm.h"
 #include "logging.h"
-#include "source.h"
 
-class SelectionDialog : public Gtk::Dialog {
+class SelectionDialog {
 public:
   SelectionDialog(Gtk::TextView& text_view);
-  void show(const std::map<std::string, std::string>& rows);
+  void show();
+  void hide();
   bool close(GdkEventFocus*);
+  void select(bool hide_window=true);
+  void move();
+  bool on_key_release(GdkEventKey* key);
+  bool on_key_press(GdkEventKey* key);
   
-  std::function<void(Gtk::ListViewText& list_view_text)> on_select;
-  
+  std::map<std::string, std::string> rows;
+
+  bool shown=false;
+  Gtk::Entry search_entry;
+  Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark;
+  int start_offset;
 private:
-  void adjust(int current_x, int current_y);
+  void resize();
   
   Gtk::TextView& text_view;
-  Gtk::ScrolledWindow scrolled_window;
-  Gtk::ListViewText list_view_text;
+  std::unique_ptr<Gtk::Window> window;
+  std::unique_ptr<Gtk::ScrolledWindow> scrolled_window;
+  std::unique_ptr<Gtk::ListViewText> list_view_text;
 };
 
 #endif  // JUCI_SELECTIONDIALOG_H_

--- a/juci/selectiondialog.h
+++ b/juci/selectiondialog.h
@@ -3,6 +3,7 @@
 
 #include "gtkmm.h"
 #include "logging.h"
+#include "tooltips.h"
 
 class SelectionDialog {
 public:
@@ -14,12 +15,13 @@ public:
   bool on_key_release(GdkEventKey* key);
   bool on_key_press(GdkEventKey* key);
   
-  std::map<std::string, std::string> rows;
+  std::map<std::string, std::pair<std::string, std::string> > rows;
 
   bool shown=false;
 private:
   void resize();
-    void select(bool hide_window=true);
+  void select(bool hide_window=true);
+  void cursor_changed();
   
   Gtk::Entry search_entry;
   Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark;
@@ -30,6 +32,7 @@ private:
   std::unique_ptr<Gtk::Window> window;
   std::unique_ptr<Gtk::ScrolledWindow> scrolled_window;
   std::unique_ptr<Gtk::ListViewText> list_view_text;
+  std::unique_ptr<Tooltips> tooltips;
 };
 
 #endif  // JUCI_SELECTIONDIALOG_H_

--- a/juci/singletons.cc
+++ b/juci/singletons.cc
@@ -1,0 +1,3 @@
+#include "singletons.h"
+
+std::unique_ptr<Source::Config> Singletons::Config::source_=std::unique_ptr<Source::Config>(new Source::Config());

--- a/juci/singletons.h
+++ b/juci/singletons.h
@@ -1,0 +1,20 @@
+#ifndef JUCI_SINGLETONS_H_
+#define JUCI_SINGLETONS_H_
+
+#include "keybindings.h"
+#include "source.h"
+#include "directories.h"
+#include "terminal.h"
+
+namespace Singletons {
+  class Config {
+  public:
+    static Source::Config *source() {
+      return source_.get();
+    }
+  private:
+    static std::unique_ptr<Source::Config> source_;
+  };
+}
+
+#endif // JUCI_SINGLETONS_H_

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -406,6 +406,9 @@ void Source::ClangView::update_types() {
         auto get_tooltip_buffer=[this, c]() {
           auto tooltip_buffer=Gtk::TextBuffer::create(get_buffer()->get_tag_table());
           tooltip_buffer->insert_at_cursor("Type: "+(*clang_tokens)[c].type);
+          auto brief_comment=clang_tokens->get_brief_comment(c);
+          if(brief_comment!="")
+            tooltip_buffer->insert_at_cursor("\n\n"+brief_comment);
           return tooltip_buffer;
         };
         

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -38,7 +38,9 @@ file_path(file_path), project_path(project_path) {
   search_start = search_end = this->get_buffer()->end();
   
   override_font(Pango::FontDescription(Singletons::Config::source()->font));
+  
   override_background_color(Gdk::RGBA(Singletons::Config::source()->background));
+  override_background_color(Gdk::RGBA(Singletons::Config::source()->background_selected), Gtk::StateFlags::STATE_FLAG_SELECTED);
   for (auto &item : Singletons::Config::source()->tags) {
     get_source_buffer()->create_tag(item.first)->property_foreground() = item.second;
   }
@@ -441,6 +443,9 @@ bool Source::ClangView::clangview_on_motion_notify_event(GdkEventMotion* event) 
 }
 
 void Source::ClangView::clangview_on_mark_set(const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark) {
+  if(get_buffer()->get_has_selection() && mark->get_name()=="selection_bound")
+    on_mark_set_timeout_connection.disconnect();
+  
   if(mark->get_name()=="insert") {
     if(selection_dialog.shown) {
       selection_dialog.hide();

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -381,8 +381,6 @@ void Source::ClangView::update_diagnostics() {
 bool Source::ClangView::clangview_on_motion_notify_event(GdkEventMotion* event) {
   Gdk::Rectangle rectangle(event->x, event->y, 1, 1);
   diagnostic_tooltips.show(rectangle);
-  auto cursor=Gdk::Cursor::create(Gdk::CursorType::XTERM);
-  get_window(Gtk::TextWindowType::TEXT_WINDOW_TEXT)->set_cursor(cursor);
   return false;
 }
 

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -300,15 +300,8 @@ get_autocomplete_suggestions(int line_number, int column, std::map<std::string, 
                                      column-1);
   for (int i = 0; i < results.size(); i++) {
     auto result=results.get(i);
-    const vector<clang::CompletionChunk> chunks_ = result.get_chunks();
-    if(chunks_.size()>0) {
-      std::vector<AutoCompleteChunk> chunks;
-      for (auto &chunk : chunks_) {
-        chunks.emplace_back(chunk);
-      }
-      suggestions.emplace_back(chunks);
-      suggestions.back().brief_comments=result.get_brief_comments();
-    }
+    suggestions.emplace_back(result.get_chunks());
+    suggestions.back().brief_comments=result.get_brief_comments();
   }
   DEBUG("Number of suggestions");
   DEBUG_VAR(suggestions.size());

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -367,7 +367,7 @@ void Source::ClangView::update_diagnostics() {
       tooltip_widget->set_editable(false);
       tooltip_widget->get_buffer()->insert_with_tag(tooltip_widget->get_buffer()->get_insert()->get_iter(), diagnostic.severity_spelling, diagnostic_tag_name);
       tooltip_widget->get_buffer()->insert_at_cursor(": \n"+diagnostic.spelling);
-      //TODO: Insert newlines in tooltip_widget->get_buffer() (use 80 chars, then newline?)
+      //TODO: Insert newlines to diagnostic.spelling (use 80 chars, then newline?)
       diagnostic_tooltips.emplace_back(tooltip_widget, *this, get_source_buffer()->create_mark(start), get_source_buffer()->create_mark(end));
       
       auto tag=buffer->create_tag();

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -587,6 +587,8 @@ bool Source::ClangView::on_key_press_event(GdkEventKey* key) {
 Source::ClangViewAutocomplete::ClangViewAutocomplete(const std::string& file_path, const std::string& project_path, Terminal::Controller& terminal):
 Source::ClangView(file_path, project_path, terminal), selection_dialog(*this) {  
   get_buffer()->signal_changed().connect([this](){
+    if(autocomplete_running || selection_dialog.shown)
+      delayed_reparse_connection.disconnect();
     if(!selection_dialog.shown) {
       auto insert=get_buffer()->get_insert();
       auto iter=insert->get_iter();

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -451,6 +451,7 @@ void Source::ClangView::clangview_on_mark_set(const Gtk::TextBuffer::iterator& i
     on_mark_set_timeout_connection.disconnect();
   
   if(mark->get_name()=="insert") {
+    autocomplete_cancel=true;
     if(selection_dialog.shown) {
       selection_dialog.hide();
     }
@@ -606,7 +607,6 @@ bool Source::ClangView::on_key_release(GdkEventKey* key) {
     std::thread autocomplete_thread([this, ac_data, line_nr, column_nr, buffer_map](){
       parsing_mutex.lock();
       *ac_data=move(get_autocomplete_suggestions(line_nr, column_nr, *buffer_map));
-      
       autocomplete_done();
       parsing_mutex.unlock();
     });

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -360,13 +360,17 @@ void Source::ClangView::update_diagnostics() {
       diagnostic_tooltips.add(diagnostic.severity_spelling+": "+diagnostic.spelling, get_source_buffer()->create_mark(start), get_source_buffer()->create_mark(end));
       auto tag=buffer->create_tag();
       tag->property_underline()=Pango::Underline::UNDERLINE_ERROR;
-      if(diagnostic.severity<=CXDiagnostic_Warning) {
-        //TODO: get color from config.json
-        tag->set_property("underline-rgba", Gdk::RGBA("orange"));
-      }
-      else {
-        //TODO: get color from config.json
-        tag->set_property("underline-rgba", Gdk::RGBA("red"));
+      auto tag_class=G_OBJECT_GET_CLASS(tag->gobj()); //For older GTK+ 3 versions:
+      auto param_spec=g_object_class_find_property(tag_class, "underline-rgba");
+      if(param_spec!=NULL) {
+        if(diagnostic.severity<=CXDiagnostic_Warning) {
+          //TODO: get color from config.json
+          tag->set_property("underline-rgba", Gdk::RGBA("orange"));
+        }
+        else {
+          //TODO: get color from config.json
+          tag->set_property("underline-rgba", Gdk::RGBA("red"));
+        }
       }
       buffer->apply_tag(tag, start, end);
     }

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -366,7 +366,8 @@ void Source::ClangView::update_diagnostics() {
       auto tooltip_widget=std::make_shared<Gtk::TextView>(Gtk::TextBuffer::create(buffer->get_tag_table()));
       tooltip_widget->set_editable(false);
       tooltip_widget->get_buffer()->insert_with_tag(tooltip_widget->get_buffer()->get_insert()->get_iter(), diagnostic.severity_spelling, diagnostic_tag_name);
-      tooltip_widget->get_buffer()->insert_at_cursor(": "+diagnostic.spelling);
+      tooltip_widget->get_buffer()->insert_at_cursor(": \n"+diagnostic.spelling);
+      //TODO: Insert newlines in tooltip_widget->get_buffer() (use 80 chars, then newline?)
       diagnostic_tooltips.emplace_back(tooltip_widget, *this, get_source_buffer()->create_mark(start), get_source_buffer()->create_mark(end));
       
       auto tag=buffer->create_tag();
@@ -381,7 +382,6 @@ void Source::ClangView::update_diagnostics() {
       buffer->apply_tag(tag, start, end);
     }
   }
-  clangview_on_mark_set(get_buffer()->get_insert()->get_iter(), get_buffer()->get_mark("insert"));
 }
 
 bool Source::ClangView::clangview_on_motion_notify_event(GdkEventMotion* event) {

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -587,8 +587,6 @@ bool Source::ClangView::on_key_press_event(GdkEventKey* key) {
 Source::ClangViewAutocomplete::ClangViewAutocomplete(const std::string& file_path, const std::string& project_path, Terminal::Controller& terminal):
 Source::ClangView(file_path, project_path, terminal), selection_dialog(*this) {  
   get_buffer()->signal_changed().connect([this](){
-    if(autocomplete_running || selection_dialog.shown)
-      delayed_reparse_connection.disconnect();
     if(!selection_dialog.shown) {
       auto insert=get_buffer()->get_insert();
       auto iter=insert->get_iter();
@@ -609,6 +607,9 @@ Source::ClangView(file_path, project_path, terminal), selection_dialog(*this) {
       else if(autocomplete_running)
         cancel_show_autocomplete=true;
     }
+    if(autocomplete_running || selection_dialog.shown)
+      delayed_reparse_connection.disconnect();
+
   });
   get_buffer()->signal_mark_set().connect([this](const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark){
     if(mark->get_name()=="insert") {
@@ -643,7 +644,6 @@ bool Source::ClangViewAutocomplete::on_key_press_event(GdkEventKey *key) {
   return ClangView::on_key_press_event(key);
 }
 void Source::ClangViewAutocomplete::start_autocomplete() {
-  delayed_reparse_connection.disconnect();
   if(!autocomplete_running) {
     autocomplete_running=true;
     cancel_show_autocomplete=false;

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -218,6 +218,7 @@ parse_thread_go(true), parse_thread_mapped(false), parse_thread_stop(false) {
   signal_key_press_event().connect(sigc::mem_fun(*this, &Source::ClangView::on_key_press), false);
   signal_key_release_event().connect(sigc::mem_fun(*this, &Source::ClangView::on_key_release), false);
   signal_motion_notify_event().connect(sigc::mem_fun(*this, &Source::ClangView::clangview_on_motion_notify_event), false);
+  signal_focus_out_event().connect(sigc::mem_fun(*this, &Source::ClangView::clangview_on_focus_out_event), false);
   get_buffer()->signal_mark_set().connect(sigc::mem_fun(*this, &Source::ClangView::clangview_on_mark_set), false);
 }
 
@@ -436,6 +437,12 @@ void Source::ClangView::clangview_on_mark_set(const Gtk::TextBuffer::iterator& i
     type_tooltips.show(rectangle);
     diagnostic_tooltips.show(rectangle);
   }
+}
+
+bool Source::ClangView::clangview_on_focus_out_event(GdkEventFocus* event) {
+    diagnostic_tooltips.hide();
+    type_tooltips.hide();
+    return false;
 }
 
 void Source::ClangView::

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -217,8 +217,8 @@ parse_thread_go(true), parse_thread_mapped(false), parse_thread_stop(false), dia
   
   signal_key_press_event().connect(sigc::mem_fun(*this, &Source::ClangView::on_key_press), false);
   signal_key_release_event().connect(sigc::mem_fun(*this, &Source::ClangView::on_key_release), false);
-  signal_motion_notify_event().connect(sigc::mem_fun(*this, &Source::ClangView::on_motion_notify_event), false);
-  get_buffer()->signal_mark_set().connect(sigc::mem_fun(*this, &Source::ClangView::on_mark_set), false);
+  signal_motion_notify_event().connect(sigc::mem_fun(*this, &Source::ClangView::clangview_on_motion_notify_event), false);
+  get_buffer()->signal_mark_set().connect(sigc::mem_fun(*this, &Source::ClangView::clangview_on_mark_set), false);
 }
 
 Source::ClangView::~ClangView() {
@@ -375,10 +375,10 @@ void Source::ClangView::update_diagnostics() {
       buffer->apply_tag(tag, start, end);
     }
   }
-  on_mark_set(get_buffer()->get_insert()->get_iter(), get_buffer()->get_mark("insert"));
+  clangview_on_mark_set(get_buffer()->get_insert()->get_iter(), get_buffer()->get_mark("insert"));
 }
 
-bool Source::ClangView::on_motion_notify_event(GdkEventMotion* event) {
+bool Source::ClangView::clangview_on_motion_notify_event(GdkEventMotion* event) {
   Gdk::Rectangle rectangle(event->x, event->y, 1, 1);
   diagnostic_tooltips.show(rectangle);
   auto cursor=Gdk::Cursor::create(Gdk::CursorType::XTERM);
@@ -386,7 +386,7 @@ bool Source::ClangView::on_motion_notify_event(GdkEventMotion* event) {
   return false;
 }
 
-void Source::ClangView::on_mark_set(const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark) {
+void Source::ClangView::clangview_on_mark_set(const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark) {
   if(mark->get_name()=="insert") {
     Gdk::Rectangle rectangle;
     get_iter_location(iterator, rectangle);

--- a/juci/source.cc
+++ b/juci/source.cc
@@ -721,7 +721,6 @@ void Source::ClangViewAutocomplete::autocomplete() {
     std::thread autocomplete_thread([this, ac_data, line_nr, column_nr, buffer_map](){
       parsing_mutex.lock();
       *ac_data=move(get_autocomplete_suggestions(line_nr, column_nr, *buffer_map));
-      cout << "selection size: " << ac_data->size() << endl;
       autocomplete_done();
       parsing_mutex.unlock();
     });

--- a/juci/source.h
+++ b/juci/source.h
@@ -85,6 +85,7 @@ namespace Source {
   public:
     ClangView(const std::string& file_path, const std::string& project_path, Terminal::Controller& terminal);
     ~ClangView();
+  private:
     // inits the syntax highligthing on file open
     void init_syntax_highlighting(const std::map<std::string, std::string>
                                 &buffers,
@@ -101,13 +102,14 @@ namespace Source {
     Tooltips type_tooltips;
     bool clangview_on_motion_notify_event(GdkEventMotion* event);
     void clangview_on_mark_set(const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark);
+    sigc::connection on_mark_set_timeout_connection;
     bool clangview_on_focus_out_event(GdkEventFocus* event);
     bool clangview_on_scroll_event(GdkEventScroll* event);
     
     static clang::Index clang_index;
     std::map<std::string, std::string> get_buffer_map() const;
     std::mutex parsing_mutex;
-  private:
+
     std::unique_ptr<clang::TranslationUnit> clang_tu;
     std::unique_ptr<clang::Tokens> clang_tokens;
     bool clang_updated=false;

--- a/juci/source.h
+++ b/juci/source.h
@@ -56,6 +56,7 @@ namespace Source {
     explicit AutoCompleteData(const std::vector<AutoCompleteChunk> &chunks) :
       chunks(chunks) { }
     std::vector<AutoCompleteChunk> chunks;
+    std::string brief_comments;
   };
 
   class View : public Gsv::View {

--- a/juci/source.h
+++ b/juci/source.h
@@ -11,6 +11,7 @@
 #include <atomic>
 #include "gtksourceviewmm.h"
 #include "terminal.h"
+#include "tooltips.h"
 
 namespace Source {
   class Config {
@@ -95,6 +96,10 @@ namespace Source {
     int reparse(const std::map<std::string, std::string> &buffers);
     std::vector<Range> extract_tokens(int, int);
     void update_syntax(const std::vector<Range> &locations);
+    void update_diagnostics();
+    Tooltips diagnostic_tooltips;
+    bool on_motion_notify_event(GdkEventMotion* event);
+    void on_mark_set(const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark);
     
     static clang::Index clang_index;
     std::map<std::string, std::string> get_buffer_map() const;

--- a/juci/source.h
+++ b/juci/source.h
@@ -102,6 +102,7 @@ namespace Source {
     Tooltips type_tooltips;
     bool clangview_on_motion_notify_event(GdkEventMotion* event);
     void clangview_on_mark_set(const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark);
+    bool clangview_on_focus_out_event(GdkEventFocus* event);
     
     static clang::Index clang_index;
     std::map<std::string, std::string> get_buffer_map() const;

--- a/juci/source.h
+++ b/juci/source.h
@@ -109,6 +109,7 @@ namespace Source {
   private:
     std::unique_ptr<clang::TranslationUnit> clang_tu;
     std::unique_ptr<clang::Tokens> clang_tokens;
+    bool clang_tokens_ready=false;
     void highlight_token(clang::Token *token,
                         std::vector<Range> *source_ranges,
                         int token_kind);

--- a/juci/source.h
+++ b/juci/source.h
@@ -20,7 +20,7 @@ namespace Source {
     bool legal_extension(std::string e) const ;
     unsigned tab_size;
     bool show_line_numbers, highlight_current_line;
-    std::string tab, background, background_tooltips, font;
+    std::string tab, background, background_selected, background_tooltips, font;
     char tab_char=' ';
     std::vector<std::string> extensions;
     std::unordered_map<std::string, std::string> tags, types;

--- a/juci/source.h
+++ b/juci/source.h
@@ -96,11 +96,11 @@ namespace Source {
     void update_types();
     Tooltips diagnostic_tooltips;
     Tooltips type_tooltips;
-    bool clangview_on_motion_notify_event(GdkEventMotion* event);
-    void clangview_on_mark_set(const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark);
+    bool on_motion_notify_event(GdkEventMotion* event);
+    void on_mark_set(const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark);
     sigc::connection delayed_tooltips_connection;
-    bool clangview_on_focus_out_event(GdkEventFocus* event);
-    bool clangview_on_scroll_event(GdkEventScroll* event);
+    bool on_focus_out_event(GdkEventFocus* event);
+    bool on_scroll_event(GdkEventScroll* event);
     static clang::Index clang_index;
     std::unique_ptr<clang::Tokens> clang_tokens;
     bool clang_readable=false;
@@ -129,14 +129,15 @@ namespace Source {
   protected:
     bool on_key_press_event(GdkEventKey* key);
   private:
-    void start_autocomplete();
+    void autocomplete();
     SelectionDialog selection_dialog;
     std::vector<Source::AutoCompleteData> get_autocomplete_suggestions(int line_number, int column, std::map<std::string, std::string>& buffer_map);
     Glib::Dispatcher autocomplete_done;
     sigc::connection autocomplete_done_connection;
-    bool autocomplete_running=false;
-    bool cancel_show_autocomplete=false;
+    bool autocomplete_starting=false;
+    bool autocomplete_cancel_starting=false;
     char last_keyval=0;
+    std::string prefix;
   };
 
   class Controller {

--- a/juci/source.h
+++ b/juci/source.h
@@ -19,7 +19,7 @@ namespace Source {
     bool legal_extension(std::string e) const ;
     unsigned tab_size;
     bool show_line_numbers, highlight_current_line;
-    std::string tab, background, font;
+    std::string tab, background, background_tooltips, font;
     char tab_char=' ';
     std::vector<std::string> extensions;
     std::unordered_map<std::string, std::string> tags, types;
@@ -59,21 +59,20 @@ namespace Source {
 
   class View : public Gsv::View {
   public:
-    View(const Source::Config& config, const std::string& file_path, const std::string& project_path);
+    View(const std::string& file_path, const std::string& project_path);
     std::string get_line(size_t line_number);
     std::string get_line_before_insert();
     std::string file_path;
     std::string project_path;
     Gtk::TextIter search_start, search_end;
   protected:
-    const Source::Config& config;
     bool on_key_press(GdkEventKey* key);
   };  // class View
   
   class GenericView : public View {
   public:
-    GenericView(const Source::Config& config, const std::string& file_path, const std::string& project_path):
-    View(config, file_path, project_path) {
+    GenericView(const std::string& file_path, const std::string& project_path):
+    View(file_path, project_path) {
       signal_key_press_event().connect(sigc::mem_fun(*this, &Source::GenericView::on_key_press), false);
     }
   private:
@@ -84,7 +83,7 @@ namespace Source {
   
   class ClangView : public View {
   public:
-    ClangView(const Source::Config& config, const std::string& file_path, const std::string& project_path, Terminal::Controller& terminal);
+    ClangView(const std::string& file_path, const std::string& project_path, Terminal::Controller& terminal);
     ~ClangView();
     // inits the syntax highligthing on file open
     void init_syntax_highlighting(const std::map<std::string, std::string>
@@ -132,8 +131,7 @@ namespace Source {
 
   class Controller {
   public:
-    Controller(const Source::Config &config,
-               const std::string& file_path, std::string project_path, Terminal::Controller& terminal);
+    Controller(const std::string& file_path, std::string project_path, Terminal::Controller& terminal);
     Glib::RefPtr<Gsv::Buffer> buffer();
     
     bool is_saved = true;

--- a/juci/source.h
+++ b/juci/source.h
@@ -97,7 +97,9 @@ namespace Source {
     std::vector<Range> extract_tokens(int, int);
     void update_syntax(const std::vector<Range> &locations);
     void update_diagnostics();
+    void update_types(std::vector<clang::Token>& tokens);
     Tooltips diagnostic_tooltips;
+    Tooltips type_tooltips;
     bool clangview_on_motion_notify_event(GdkEventMotion* event);
     void clangview_on_mark_set(const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark);
     

--- a/juci/source.h
+++ b/juci/source.h
@@ -43,19 +43,11 @@ namespace Source {
     int kind;
   };
 
-  class AutoCompleteChunk {
-  public:
-    explicit AutoCompleteChunk(const clang::CompletionChunk &clang_chunk) :
-      chunk(clang_chunk.chunk()), kind(clang_chunk.kind()) { }
-    std::string chunk;
-    enum clang::CompletionChunkKind kind;
-  };
-
   class AutoCompleteData {
   public:
-    explicit AutoCompleteData(const std::vector<AutoCompleteChunk> &chunks) :
+    explicit AutoCompleteData(const std::vector<clang::CompletionChunk> &chunks) :
       chunks(chunks) { }
-    std::vector<AutoCompleteChunk> chunks;
+    std::vector<clang::CompletionChunk> chunks;
     std::string brief_comments;
   };
 

--- a/juci/source.h
+++ b/juci/source.h
@@ -93,7 +93,7 @@ namespace Source {
                                 int start_offset,
                                 int end_offset,
                                 clang::Index *index);
-    std::vector<Source::AutoCompleteData> get_autocomplete_suggestions(int line_number, int column);
+    std::vector<Source::AutoCompleteData> get_autocomplete_suggestions(int line_number, int column, std::map<std::string, std::string>& buffer_map);
     SelectionDialog selection_dialog;
     int reparse(const std::map<std::string, std::string> &buffers);
     std::vector<Range> extract_tokens(int, int);
@@ -126,6 +126,10 @@ namespace Source {
     Terminal::Controller& terminal;
     std::shared_ptr<Terminal::InProgress> parsing_in_progress;
     
+    Glib::Dispatcher autocomplete_done;
+    std::function<void()> autocomplete_done_function;
+    bool autocomplete_running=false;
+    bool autocomplete_cancel=false;
     Glib::Dispatcher parse_done;
     Glib::Dispatcher parse_start;
     std::thread parse_thread;

--- a/juci/source.h
+++ b/juci/source.h
@@ -98,8 +98,8 @@ namespace Source {
     void update_syntax(const std::vector<Range> &locations);
     void update_diagnostics();
     Tooltips diagnostic_tooltips;
-    bool on_motion_notify_event(GdkEventMotion* event);
-    void on_mark_set(const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark);
+    bool clangview_on_motion_notify_event(GdkEventMotion* event);
+    void clangview_on_mark_set(const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark);
     
     static clang::Index clang_index;
     std::map<std::string, std::string> get_buffer_map() const;

--- a/juci/source.h
+++ b/juci/source.h
@@ -102,6 +102,7 @@ namespace Source {
     bool clangview_on_motion_notify_event(GdkEventMotion* event);
     void clangview_on_mark_set(const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark);
     bool clangview_on_focus_out_event(GdkEventFocus* event);
+    bool clangview_on_scroll_event(GdkEventScroll* event);
     
     static clang::Index clang_index;
     std::map<std::string, std::string> get_buffer_map() const;
@@ -109,7 +110,7 @@ namespace Source {
   private:
     std::unique_ptr<clang::TranslationUnit> clang_tu;
     std::unique_ptr<clang::Tokens> clang_tokens;
-    bool clang_tokens_ready=false;
+    bool clang_updated=false;
     void highlight_token(clang::Token *token,
                         std::vector<Range> *source_ranges,
                         int token_kind);

--- a/juci/source.h
+++ b/juci/source.h
@@ -96,16 +96,16 @@ namespace Source {
                                 clang::Index *index);
     std::vector<Source::AutoCompleteData> get_autocomplete_suggestions(int line_number, int column, std::map<std::string, std::string>& buffer_map);
     SelectionDialog selection_dialog;
+    
     int reparse(const std::map<std::string, std::string> &buffers);
-    std::vector<Range> extract_tokens(int, int);
-    void update_syntax(const std::vector<Range> &locations);
+    void update_syntax();
     void update_diagnostics();
     void update_types();
     Tooltips diagnostic_tooltips;
     Tooltips type_tooltips;
     bool clangview_on_motion_notify_event(GdkEventMotion* event);
     void clangview_on_mark_set(const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark);
-    sigc::connection on_mark_set_timeout_connection;
+    sigc::connection delayed_tooltips_connection;
     bool clangview_on_focus_out_event(GdkEventFocus* event);
     bool clangview_on_scroll_event(GdkEventScroll* event);
     
@@ -115,7 +115,7 @@ namespace Source {
 
     std::unique_ptr<clang::TranslationUnit> clang_tu;
     std::unique_ptr<clang::Tokens> clang_tokens;
-    bool clang_updated=false;
+    bool clang_readable=false;
     void highlight_token(clang::Token *token,
                         std::vector<Range> *source_ranges,
                         int token_kind);
@@ -125,12 +125,14 @@ namespace Source {
     bool on_key_press(GdkEventKey* key);
     bool on_key_release(GdkEventKey* key);
     Terminal::Controller& terminal;
-    std::shared_ptr<Terminal::InProgress> parsing_in_progress;
     
     Glib::Dispatcher autocomplete_done;
-    std::function<void()> autocomplete_done_function;
+    sigc::connection autocomplete_done_connection;
+    
+    sigc::connection delayed_reparse_connection;
+    std::shared_ptr<Terminal::InProgress> parsing_in_progress;
     bool autocomplete_running=false;
-    bool autocomplete_cancel=false;
+    bool cancel_show_autocomplete=false;
     Glib::Dispatcher parse_done;
     Glib::Dispatcher parse_start;
     std::thread parse_thread;

--- a/juci/source.h
+++ b/juci/source.h
@@ -136,7 +136,7 @@ namespace Source {
     sigc::connection autocomplete_done_connection;
     bool autocomplete_starting=false;
     bool autocomplete_cancel_starting=false;
-    char last_keyval=0;
+    guint last_keyval=0;
     std::string prefix;
   };
 

--- a/juci/source.h
+++ b/juci/source.h
@@ -96,7 +96,7 @@ namespace Source {
     std::vector<Range> extract_tokens(int, int);
     void update_syntax(const std::vector<Range> &locations);
     void update_diagnostics();
-    void update_types(std::vector<clang::Token>& tokens);
+    void update_types();
     Tooltips diagnostic_tooltips;
     Tooltips type_tooltips;
     bool clangview_on_motion_notify_event(GdkEventMotion* event);
@@ -107,7 +107,8 @@ namespace Source {
     std::map<std::string, std::string> get_buffer_map() const;
     std::mutex parsing_mutex;
   private:
-    std::unique_ptr<clang::TranslationUnit> tu_; //use unique_ptr since it is not initialized in constructor
+    std::unique_ptr<clang::TranslationUnit> clang_tu;
+    std::unique_ptr<clang::Tokens> clang_tokens;
     void highlight_token(clang::Token *token,
                         std::vector<Range> *source_ranges,
                         int token_kind);

--- a/juci/source.h
+++ b/juci/source.h
@@ -12,6 +12,7 @@
 #include "gtksourceviewmm.h"
 #include "terminal.h"
 #include "tooltips.h"
+#include "selectiondialog.h"
 
 namespace Source {
   class Config {
@@ -93,6 +94,7 @@ namespace Source {
                                 int end_offset,
                                 clang::Index *index);
     std::vector<Source::AutoCompleteData> get_autocomplete_suggestions(int line_number, int column);
+    SelectionDialog selection_dialog;
     int reparse(const std::map<std::string, std::string> &buffers);
     std::vector<Range> extract_tokens(int, int);
     void update_syntax(const std::vector<Range> &locations);

--- a/juci/tooltips.cc
+++ b/juci/tooltips.cc
@@ -1,94 +1,89 @@
 #include "tooltips.h"
+#include <thread>
 
-Gdk::Rectangle Tooltips::tooltips_rectangle=Gdk::Rectangle();
+Gdk::Rectangle Tooltips::drawn_tooltips_rectangle=Gdk::Rectangle();
 
-Tooltip::Tooltip(Gtk::TextView& text_view, const std::string& label_text, 
+Tooltip::Tooltip(std::shared_ptr<Gtk::Widget> widget, Gtk::TextView& text_view, 
 Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark):
-text_view(text_view), Gtk::Dialog("", (Gtk::Window&)*text_view.get_toplevel()), label(label_text), 
+widget(widget), text_view(text_view), Gtk::Dialog("", (Gtk::Window&)*text_view.get_toplevel()), 
 start_mark(start_mark), end_mark(end_mark) {
-  get_content_area()->add(label);
+  get_content_area()->add(*widget);
   property_decorated()=false;
   set_accept_focus(false);
+  signal_realize().connect([this](){
+    adjust(); //Fix for older GTK+ versions?
+  });
 }
 
 void Tooltip::update() {
   auto iter=start_mark->get_iter();
   auto end_iter=end_mark->get_iter();
   if(iter.get_offset()<end_iter.get_offset()) {
-    text_view.get_iter_location(iter, text_rectangle);
+    text_view.get_iter_location(iter, activation_rectangle);
     iter++;
     while(iter!=end_iter) {
       Gdk::Rectangle rectangle;
       text_view.get_iter_location(iter, rectangle);
-      text_rectangle.join(rectangle);
+      activation_rectangle.join(rectangle);
       iter++;
     }
   }
   int location_window_x, location_window_y;
-  text_view.buffer_to_window_coords(Gtk::TextWindowType::TEXT_WINDOW_TEXT, text_rectangle.get_x(), text_rectangle.get_y(), location_window_x, location_window_y);
-  text_rectangle.set_x(location_window_x);
-  text_rectangle.set_y(location_window_y);
+  text_view.buffer_to_window_coords(Gtk::TextWindowType::TEXT_WINDOW_TEXT, activation_rectangle.get_x(), activation_rectangle.get_y(), location_window_x, location_window_y);
+  activation_rectangle.set_x(location_window_x);
+  activation_rectangle.set_y(location_window_y);
+  adjusted=false;
 }
 
 void Tooltip::adjust() {
+  if(adjusted)
+    return;
   int tooltip_width, tooltip_height;
   get_size(tooltip_width, tooltip_height);
   int root_x, root_y;
-  text_view.get_window(Gtk::TextWindowType::TEXT_WINDOW_TEXT)->get_root_coords(text_rectangle.get_x(), text_rectangle.get_y(), root_x, root_y);
+  text_view.get_window(Gtk::TextWindowType::TEXT_WINDOW_TEXT)->get_root_coords(activation_rectangle.get_x(), activation_rectangle.get_y(), root_x, root_y);
   Gdk::Rectangle rectangle;
   rectangle.set_x(root_x);
   rectangle.set_y(root_y-tooltip_height);
   rectangle.set_width(tooltip_width);
   rectangle.set_height(tooltip_height);
   
-  if(Tooltips::tooltips_rectangle.get_width()!=0) {
-    if(rectangle.intersects(Tooltips::tooltips_rectangle))
-      rectangle.set_y(Tooltips::tooltips_rectangle.get_y()-tooltip_height);
-    Tooltips::tooltips_rectangle.join(rectangle);
+  if(Tooltips::drawn_tooltips_rectangle.get_width()!=0) {
+    if(rectangle.intersects(Tooltips::drawn_tooltips_rectangle))
+      rectangle.set_y(Tooltips::drawn_tooltips_rectangle.get_y()-tooltip_height);
+    Tooltips::drawn_tooltips_rectangle.join(rectangle);
   }
   else
-    Tooltips::tooltips_rectangle=rectangle;
+    Tooltips::drawn_tooltips_rectangle=rectangle;
 
-  if(rectangle.get_y()<0)
-    rectangle.set_y(0);
   move(rectangle.get_x(), rectangle.get_y());
+  adjusted=true;
 }
 
-void Tooltips::add(const std::string& text, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark) {
-  tooltips.emplace_back(new Tooltip(text_view, text, start_mark, end_mark));
-}
-
-//If you want to show tooltips from several Tooltips-objects at once, you might want to set clear_tooltips_rectangle=true only on the first one.
-//If not, they would overlap (clear_tooltips_rectangle=false to avoid this on the following Tooltips-objects)
-void Tooltips::show(const Gdk::Rectangle& rectangle, bool clear_tooltips_rectangle) {
-  if(clear_tooltips_rectangle)
-    tooltips_rectangle=Gdk::Rectangle();
-  for(auto& tooltip: tooltips) {
-    tooltip->update();
-    if(rectangle.intersects(tooltip->text_rectangle)) {
-      tooltip->show_all();
-      tooltip->adjust();
+void Tooltips::show(const Gdk::Rectangle& rectangle) {
+  for(auto& tooltip: *this) {
+    tooltip.update();
+    if(rectangle.intersects(tooltip.activation_rectangle)) {
+      tooltip.show_all();
+      if(tooltip.get_realized())
+        tooltip.adjust();
     }
     else
-      tooltip->hide();
+      tooltip.hide();
   }
-  text_view.grab_focus();
 }
 
-//See Tooltips::show(const Gdk::Rectangle& rectangle, bool clear_tooltips_rectangle=true)
-void Tooltips::show(bool clear_tooltips_rectangle) {
-  if(clear_tooltips_rectangle)
-    tooltips_rectangle=Gdk::Rectangle();
-  for(auto& tooltip: tooltips) {
-    tooltip->update();
-    tooltip->show_all();
-    tooltip->adjust();
+void Tooltips::show() {
+  for(auto& tooltip: *this) {
+    tooltip.update();
+    tooltip.show_all();
+    if(tooltip.get_realized())
+      tooltip.adjust();
   }
-  text_view.grab_focus();
 }
 
 void Tooltips::hide() {
-  for(auto& tooltip: tooltips) {
-    tooltip->hide();
+  for(auto& tooltip: *this) {
+    tooltip.hide();
   }
 }

--- a/juci/tooltips.cc
+++ b/juci/tooltips.cc
@@ -58,7 +58,7 @@ void Tooltips::add(const std::string& text, Glib::RefPtr<Gtk::TextBuffer::Mark> 
 }
 
 void Tooltips::show(const Gdk::Rectangle& rectangle) {
-  init_adjustments();
+  tooltips_rectangle=Gdk::Rectangle();
   for(auto& tooltip: tooltips) {
     tooltip->update();
     if(rectangle.intersects(tooltip->text_rectangle)) {
@@ -71,7 +71,7 @@ void Tooltips::show(const Gdk::Rectangle& rectangle) {
 }
 
 void Tooltips::show() {
-  init_adjustments();
+  tooltips_rectangle=Gdk::Rectangle();
   for(auto& tooltip: tooltips) {
     tooltip->update();
     tooltip->show_all();
@@ -80,7 +80,6 @@ void Tooltips::show() {
 }
 
 void Tooltips::hide() {
-  init_adjustments();
   for(auto& tooltip: tooltips) {
     tooltip->hide();
   }

--- a/juci/tooltips.cc
+++ b/juci/tooltips.cc
@@ -72,6 +72,7 @@ void Tooltips::show(const Gdk::Rectangle& rectangle, bool clear_tooltips_rectang
     else
       tooltip->hide();
   }
+  text_view.grab_focus();
 }
 
 //See Tooltips::show(const Gdk::Rectangle& rectangle, bool clear_tooltips_rectangle=true)
@@ -83,6 +84,7 @@ void Tooltips::show(bool clear_tooltips_rectangle) {
     tooltip->show_all();
     tooltip->adjust();
   }
+  text_view.grab_focus();
 }
 
 void Tooltips::hide() {

--- a/juci/tooltips.cc
+++ b/juci/tooltips.cc
@@ -5,11 +5,13 @@ Gdk::Rectangle Tooltips::drawn_tooltips_rectangle=Gdk::Rectangle();
 
 Tooltip::Tooltip(std::shared_ptr<Gtk::Widget> widget, Gtk::TextView& text_view, 
 Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark):
-widget(widget), text_view(text_view), Gtk::Dialog("", (Gtk::Window&)*text_view.get_toplevel()), 
+widget(widget), text_view(text_view), Gtk::Window(Gtk::WindowType::WINDOW_POPUP), 
 start_mark(start_mark), end_mark(end_mark) {
-  get_content_area()->add(*widget);
+  add(*widget);
   property_decorated()=false;
   set_accept_focus(false);
+  set_skip_taskbar_hint(true);
+  set_default_size(0, 0);
   signal_realize().connect([this](){
     adjust(); //Fix for older GTK+ versions?
   });

--- a/juci/tooltips.cc
+++ b/juci/tooltips.cc
@@ -1,0 +1,71 @@
+#include "tooltips.h"
+#include <iostream>
+
+Tooltip::Tooltip(Gtk::TextView& text_view, const std::string& label_text, 
+Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark, Gdk::Rectangle &tooltips_rectangle): 
+text_view(text_view), Gtk::Dialog("", (Gtk::Window&)*text_view.get_toplevel()), label(label_text), 
+start_mark(start_mark), end_mark(end_mark), tooltips_rectangle(tooltips_rectangle) {
+  get_content_area()->add(label);
+  property_decorated()=false;
+  set_accept_focus(false);
+}
+
+void Tooltip::update() {
+  auto iter=start_mark->get_iter();
+  auto end_iter=end_mark->get_iter();
+  if(iter.get_offset()<end_iter.get_offset()) {
+    text_view.get_iter_location(iter, text_rectangle);
+    iter++;
+    while(iter!=end_iter) {
+      Gdk::Rectangle rectangle;
+      text_view.get_iter_location(iter, rectangle);
+      text_rectangle.join(rectangle);
+      iter++;
+    }
+  }
+  int location_window_x, location_window_y;
+  text_view.buffer_to_window_coords(Gtk::TextWindowType::TEXT_WINDOW_TEXT, text_rectangle.get_x(), text_rectangle.get_y(), location_window_x, location_window_y);
+  text_rectangle.set_x(location_window_x);
+  text_rectangle.set_y(location_window_y);
+}
+
+void Tooltip::adjust() {
+  int tooltip_width, tooltip_height;
+  get_size(tooltip_width, tooltip_height);
+  int root_x, root_y;
+  text_view.get_window(Gtk::TextWindowType::TEXT_WINDOW_TEXT)->get_root_coords(text_rectangle.get_x(), text_rectangle.get_y(), root_x, root_y);
+  Gdk::Rectangle rectangle;
+  rectangle.set_x(root_x);
+  rectangle.set_y(root_y-tooltip_height);
+  rectangle.set_width(tooltip_width);
+  rectangle.set_height(tooltip_height);
+  
+  if(tooltips_rectangle.get_width()!=0) {
+    if(rectangle.intersects(tooltips_rectangle))
+      rectangle.set_y(tooltips_rectangle.get_y()-tooltip_height);
+    tooltips_rectangle.join(rectangle);
+  }
+  else
+    tooltips_rectangle=rectangle;
+
+  if(rectangle.get_y()<0)
+    rectangle.set_y(0);
+  move(rectangle.get_x(), rectangle.get_y());
+}
+
+void Tooltips::add(const std::string& text, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark) {
+  tooltips.emplace_back(new Tooltip(text_view, text, start_mark, end_mark, tooltips_rectangle));
+}
+
+void Tooltips::show(const Gdk::Rectangle& rectangle) {
+  init_adjustments();
+  for(auto& tooltip: tooltips) {
+    tooltip->update();
+    if(rectangle.intersects(tooltip->text_rectangle)) {
+      tooltip->show_all();
+      tooltip->adjust();
+    }
+    else
+      tooltip->hide();
+  }
+}

--- a/juci/tooltips.cc
+++ b/juci/tooltips.cc
@@ -37,6 +37,8 @@ void Tooltip::adjust() {
     //init window
     window=std::unique_ptr<Gtk::Window>(new Gtk::Window(Gtk::WindowType::WINDOW_POPUP));
     
+    window->set_events(Gdk::POINTER_MOTION_MASK);
+    window->signal_motion_notify_event().connect(sigc::mem_fun(*this, &Tooltip::tooltip_on_motion_notify_event), false);
     window->property_decorated()=false;
     window->set_accept_focus(false);
     window->set_skip_taskbar_hint(true);
@@ -68,6 +70,11 @@ void Tooltip::adjust() {
     Tooltips::drawn_tooltips_rectangle=rectangle;
 
   window->move(rectangle.get_x(), rectangle.get_y());
+}
+
+bool Tooltip::tooltip_on_motion_notify_event(GdkEventMotion* event) {
+  window->hide();
+  return false;
 }
 
 void Tooltips::show(const Gdk::Rectangle& rectangle) {

--- a/juci/tooltips.cc
+++ b/juci/tooltips.cc
@@ -3,18 +3,19 @@
 
 Gdk::Rectangle Tooltips::drawn_tooltips_rectangle=Gdk::Rectangle();
 
-Tooltip::Tooltip(std::shared_ptr<Gtk::Widget> widget, Gtk::TextView& text_view, 
+Tooltip::Tooltip(std::shared_ptr<Gtk::TextView> tooltip_widget, Gtk::TextView& text_view, 
 Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark):
-widget(widget), text_view(text_view), Gtk::Window(Gtk::WindowType::WINDOW_POPUP), 
+tooltip_widget(tooltip_widget), text_view(text_view), Gtk::Window(Gtk::WindowType::WINDOW_POPUP), 
 start_mark(start_mark), end_mark(end_mark) {
-  add(*widget);
+  add(*tooltip_widget);
   property_decorated()=false;
   set_accept_focus(false);
   set_skip_taskbar_hint(true);
   set_default_size(0, 0);
-  signal_realize().connect([this](){
-    adjust(); //Fix for older GTK+ versions?
-  });
+  
+  auto layout=Pango::Layout::create(tooltip_widget->get_pango_context());
+  layout->set_text(tooltip_widget->get_buffer()->get_text());
+  layout->get_pixel_size(tooltip_width, tooltip_height);
 }
 
 void Tooltip::update() {
@@ -34,14 +35,9 @@ void Tooltip::update() {
   text_view.buffer_to_window_coords(Gtk::TextWindowType::TEXT_WINDOW_TEXT, activation_rectangle.get_x(), activation_rectangle.get_y(), location_window_x, location_window_y);
   activation_rectangle.set_x(location_window_x);
   activation_rectangle.set_y(location_window_y);
-  adjusted=false;
 }
 
 void Tooltip::adjust() {
-  if(adjusted)
-    return;
-  int tooltip_width, tooltip_height;
-  get_size(tooltip_width, tooltip_height);
   int root_x, root_y;
   text_view.get_window(Gtk::TextWindowType::TEXT_WINDOW_TEXT)->get_root_coords(activation_rectangle.get_x(), activation_rectangle.get_y(), root_x, root_y);
   Gdk::Rectangle rectangle;
@@ -59,16 +55,14 @@ void Tooltip::adjust() {
     Tooltips::drawn_tooltips_rectangle=rectangle;
 
   move(rectangle.get_x(), rectangle.get_y());
-  adjusted=true;
 }
 
 void Tooltips::show(const Gdk::Rectangle& rectangle) {
   for(auto& tooltip: *this) {
     tooltip.update();
     if(rectangle.intersects(tooltip.activation_rectangle)) {
+      tooltip.adjust();
       tooltip.show_all();
-      if(tooltip.get_realized())
-        tooltip.adjust();
     }
     else
       tooltip.hide();
@@ -78,9 +72,8 @@ void Tooltips::show(const Gdk::Rectangle& rectangle) {
 void Tooltips::show() {
   for(auto& tooltip: *this) {
     tooltip.update();
+    tooltip.adjust();
     tooltip.show_all();
-    if(tooltip.get_realized())
-      tooltip.adjust();
   }
 }
 

--- a/juci/tooltips.cc
+++ b/juci/tooltips.cc
@@ -69,3 +69,19 @@ void Tooltips::show(const Gdk::Rectangle& rectangle) {
       tooltip->hide();
   }
 }
+
+void Tooltips::show() {
+  init_adjustments();
+  for(auto& tooltip: tooltips) {
+    tooltip->update();
+    tooltip->show_all();
+    tooltip->adjust();
+  }
+}
+
+void Tooltips::hide() {
+  init_adjustments();
+  for(auto& tooltip: tooltips) {
+    tooltip->hide();
+  }
+}

--- a/juci/tooltips.cc
+++ b/juci/tooltips.cc
@@ -1,5 +1,5 @@
 #include "tooltips.h"
-#include <thread>
+#include "singletons.h"
 
 Gdk::Rectangle Tooltips::drawn_tooltips_rectangle=Gdk::Rectangle();
 
@@ -46,11 +46,13 @@ void Tooltip::adjust() {
 
     tooltip_widget=std::unique_ptr<Gtk::TextView>(new Gtk::TextView(this->get_buffer()));
     tooltip_widget->set_editable(false);
+    tooltip_widget->override_background_color(Gdk::RGBA(Singletons::Config::source()->background_tooltips)); 
     window->add(*tooltip_widget);
 
     auto layout=Pango::Layout::create(tooltip_widget->get_pango_context());
     layout->set_text(tooltip_widget->get_buffer()->get_text());
     layout->get_pixel_size(tooltip_width, tooltip_height);
+    tooltip_height+=2;
   }
   
   int root_x, root_y;

--- a/juci/tooltips.h
+++ b/juci/tooltips.h
@@ -6,18 +6,18 @@
 
 class Tooltip : public Gtk::Window {
 public:
-  Tooltip(std::shared_ptr<Gtk::Widget> widget, Gtk::TextView& text_view, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark);
+  Tooltip(std::shared_ptr<Gtk::TextView> tooltip_widget, Gtk::TextView& text_view, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark);
   
   void update();
   void adjust();
   
   Gdk::Rectangle activation_rectangle;
-  bool adjusted=false;
 private:
-  std::shared_ptr<Gtk::Widget> widget;
+  std::shared_ptr<Gtk::TextView> tooltip_widget;
   Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark;
   Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark;
   Gtk::TextView& text_view;
+  int tooltip_width, tooltip_height;
 };
 
 class Tooltips : public std::list<Tooltip> {

--- a/juci/tooltips.h
+++ b/juci/tooltips.h
@@ -6,7 +6,7 @@
 
 class Tooltip : public Gtk::Dialog {
 public:
-  Tooltip(Gtk::TextView& text_view, const std::string& label_text, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark, Gdk::Rectangle &tooltips_rectangle);
+  Tooltip(Gtk::TextView& text_view, const std::string& label_text, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark);
   
   void update();
   void adjust();
@@ -18,7 +18,6 @@ public:
 
 private:
   Gtk::TextView& text_view;
-  Gdk::Rectangle &tooltips_rectangle;
 };
 
 class Tooltips {
@@ -29,11 +28,11 @@ public:
   
   void add(const std::string& text, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark);
   
-  void show(const Gdk::Rectangle& rectangle);
-  void show();
+  void show(const Gdk::Rectangle& rectangle, bool clear_tooltips_rectangle=true);
+  void show(bool clear_tooltips_rectangle=true);
   void hide();
   
-  Gdk::Rectangle tooltips_rectangle;
+  static Gdk::Rectangle tooltips_rectangle;
 private:
   Gtk::TextView& text_view;
   std::vector<std::unique_ptr<Tooltip> > tooltips;

--- a/juci/tooltips.h
+++ b/juci/tooltips.h
@@ -1,0 +1,42 @@
+#ifndef JUCI_TOOLTIPS_H_
+#define JUCI_TOOLTIPS_H_
+#include "gtkmm.h"
+#include <string>
+#include <vector>
+
+class Tooltip : public Gtk::Dialog {
+public:
+  Tooltip(Gtk::TextView& text_view, const std::string& label_text, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark, Gdk::Rectangle &tooltips_rectangle);
+  
+  void update();
+  void adjust();
+  
+  Gtk::Label label;
+  Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark;
+  Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark;
+  Gdk::Rectangle text_rectangle;
+
+private:
+  Gtk::TextView& text_view;
+  Gdk::Rectangle &tooltips_rectangle;
+};
+
+class Tooltips {
+public:
+  Tooltips(Gtk::TextView& text_view): text_view(text_view) {}
+
+  void init_adjustments() {tooltips_rectangle=Gdk::Rectangle();}
+  
+  void clear() {tooltips.clear();}
+  
+  void add(const std::string& text, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark);
+  
+  void show(const Gdk::Rectangle& rectangle);
+  
+  Gdk::Rectangle tooltips_rectangle;
+private:
+  Gtk::TextView& text_view;
+  std::vector<std::unique_ptr<Tooltip> > tooltips;
+};
+
+#endif  // JUCI_TOOLTIPS_H_

--- a/juci/tooltips.h
+++ b/juci/tooltips.h
@@ -4,16 +4,19 @@
 #include <string>
 #include <list>
 
-class Tooltip : public Gtk::Window {
+class Tooltip {
 public:
-  Tooltip(std::shared_ptr<Gtk::TextView> tooltip_widget, Gtk::TextView& text_view, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark);
+  Tooltip(std::function<Glib::RefPtr<Gtk::TextBuffer>()> get_buffer, Gtk::TextView& text_view, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark);
+  ~Tooltip();
   
   void update();
   void adjust();
   
   Gdk::Rectangle activation_rectangle;
+  std::unique_ptr<Gtk::Window> window;
 private:
-  std::shared_ptr<Gtk::TextView> tooltip_widget;
+  std::function<Glib::RefPtr<Gtk::TextBuffer>()> get_buffer;
+  std::unique_ptr<Gtk::TextView> tooltip_widget;
   Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark;
   Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark;
   Gtk::TextView& text_view;

--- a/juci/tooltips.h
+++ b/juci/tooltips.h
@@ -24,8 +24,6 @@ private:
 class Tooltips {
 public:
   Tooltips(Gtk::TextView& text_view): text_view(text_view) {}
-
-  void init_adjustments() {tooltips_rectangle=Gdk::Rectangle();}
   
   void clear() {tooltips.clear();}
   

--- a/juci/tooltips.h
+++ b/juci/tooltips.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <list>
 
-class Tooltip : public Gtk::Dialog {
+class Tooltip : public Gtk::Window {
 public:
   Tooltip(std::shared_ptr<Gtk::Widget> widget, Gtk::TextView& text_view, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark);
   

--- a/juci/tooltips.h
+++ b/juci/tooltips.h
@@ -32,6 +32,8 @@ public:
   void add(const std::string& text, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark);
   
   void show(const Gdk::Rectangle& rectangle);
+  void show();
+  void hide();
   
   Gdk::Rectangle tooltips_rectangle;
 private:

--- a/juci/tooltips.h
+++ b/juci/tooltips.h
@@ -15,6 +15,8 @@ public:
   Gdk::Rectangle activation_rectangle;
   std::unique_ptr<Gtk::Window> window;
 private:
+  bool tooltip_on_motion_notify_event(GdkEventMotion* event);
+  
   std::function<Glib::RefPtr<Gtk::TextBuffer>()> get_buffer;
   std::unique_ptr<Gtk::TextView> tooltip_widget;
   Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark;

--- a/juci/tooltips.h
+++ b/juci/tooltips.h
@@ -2,40 +2,32 @@
 #define JUCI_TOOLTIPS_H_
 #include "gtkmm.h"
 #include <string>
-#include <vector>
+#include <list>
 
 class Tooltip : public Gtk::Dialog {
 public:
-  Tooltip(Gtk::TextView& text_view, const std::string& label_text, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark);
+  Tooltip(std::shared_ptr<Gtk::Widget> widget, Gtk::TextView& text_view, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark);
   
   void update();
   void adjust();
   
-  Gtk::Label label;
+  Gdk::Rectangle activation_rectangle;
+  bool adjusted=false;
+private:
+  std::shared_ptr<Gtk::Widget> widget;
   Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark;
   Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark;
-  Gdk::Rectangle text_rectangle;
-
-private:
   Gtk::TextView& text_view;
 };
 
-class Tooltips {
+class Tooltips : public std::list<Tooltip> {
 public:
-  Tooltips(Gtk::TextView& text_view): text_view(text_view) {}
-  
-  void clear() {tooltips.clear();}
-  
-  void add(const std::string& text, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, Glib::RefPtr<Gtk::TextBuffer::Mark> end_mark);
-  
-  void show(const Gdk::Rectangle& rectangle, bool clear_tooltips_rectangle=true);
-  void show(bool clear_tooltips_rectangle=true);
+  void init() {drawn_tooltips_rectangle=Gdk::Rectangle();}
+  void show(const Gdk::Rectangle& rectangle);
+  void show();
   void hide();
   
-  static Gdk::Rectangle tooltips_rectangle;
-private:
-  Gtk::TextView& text_view;
-  std::vector<std::unique_ptr<Tooltip> > tooltips;
+  static Gdk::Rectangle drawn_tooltips_rectangle;
 };
 
 #endif  // JUCI_TOOLTIPS_H_

--- a/juci/tooltips.h
+++ b/juci/tooltips.h
@@ -10,7 +10,7 @@ public:
   ~Tooltip();
   
   void update();
-  void adjust();
+  void adjust(bool disregard_drawn=false);
   
   Gdk::Rectangle activation_rectangle;
   std::unique_ptr<Gtk::Window> window;
@@ -28,8 +28,8 @@ private:
 class Tooltips : public std::list<Tooltip> {
 public:
   void init() {drawn_tooltips_rectangle=Gdk::Rectangle();}
-  void show(const Gdk::Rectangle& rectangle);
-  void show();
+  void show(const Gdk::Rectangle& rectangle, bool disregard_drawn=false);
+  void show(bool disregard_drawn=false);
   void hide();
   
   static Gdk::Rectangle drawn_tooltips_rectangle;

--- a/juci/window.cc
+++ b/juci/window.cc
@@ -14,6 +14,7 @@ Window::Window() :
   INFO("Create Window");
   set_title("juCi++");
   set_default_size(600, 400);
+  set_events(Gdk::POINTER_MOTION_MASK);
   add(window_box_);
   keybindings_.action_group_menu()->add(Gtk::Action::create("FileQuit",
                                                             "Quit juCi++"),

--- a/juci/window.cc
+++ b/juci/window.cc
@@ -13,7 +13,7 @@ Window::Window() :
   INFO("Create Window");
   set_title("juCi++");
   set_default_size(600, 400);
-  set_events(Gdk::POINTER_MOTION_MASK|Gdk::FOCUS_CHANGE_MASK);
+  set_events(Gdk::POINTER_MOTION_MASK|Gdk::FOCUS_CHANGE_MASK|Gdk::SCROLL_MASK);
   add(window_box_);
   keybindings.action_group_menu()->add(Gtk::Action::create("FileQuit",
                                                             "Quit juCi++"),

--- a/juci/window.cc
+++ b/juci/window.cc
@@ -3,65 +3,64 @@
 
 Window::Window() :
   window_box_(Gtk::ORIENTATION_VERTICAL),
-  main_config_(),
-  keybindings_(main_config_.keybindings_cfg),
-  terminal(main_config_.terminal_cfg),
-  notebook(keybindings(), terminal,
-            main_config_.source_cfg,
-            main_config_.dir_cfg),
-  menu_(keybindings()),
-  api_(menu_, notebook) {
+  main_config(),
+  keybindings(main_config.keybindings_cfg),
+  terminal(main_config.terminal_cfg),
+  notebook(keybindings, terminal,
+            main_config.dir_cfg),
+  menu(keybindings),
+  api(menu, notebook) {
   INFO("Create Window");
   set_title("juCi++");
   set_default_size(600, 400);
   set_events(Gdk::POINTER_MOTION_MASK|Gdk::FOCUS_CHANGE_MASK);
   add(window_box_);
-  keybindings_.action_group_menu()->add(Gtk::Action::create("FileQuit",
+  keybindings.action_group_menu()->add(Gtk::Action::create("FileQuit",
                                                             "Quit juCi++"),
-                                        Gtk::AccelKey(keybindings_.config_
+                                        Gtk::AccelKey(keybindings.config_
                                                       .key_map()["quit"]),
                                         [this]() {
                                           OnWindowHide();
                                         });
-  keybindings_.action_group_menu()->add(Gtk::Action::create("FileOpenFile",
+  keybindings.action_group_menu()->add(Gtk::Action::create("FileOpenFile",
                                                             "Open file"),
-                                        Gtk::AccelKey(keybindings_.config_
+                                        Gtk::AccelKey(keybindings.config_
                                                       .key_map()["open_file"]),
                                         [this]() {
                                           OnOpenFile();
                                         });
-  keybindings_.action_group_menu()->add(Gtk::Action::create("FileOpenFolder",
+  keybindings.action_group_menu()->add(Gtk::Action::create("FileOpenFolder",
                                                             "Open folder"),
-                                        Gtk::AccelKey(keybindings_.config_
+                                        Gtk::AccelKey(keybindings.config_
                                                       .key_map()["open_folder"]),
                                         [this]() {
                                           OnFileOpenFolder();
                                         });
-  keybindings_.
+  keybindings.
     action_group_menu()->
     add(Gtk::Action::create("FileSaveAs",
 			    "Save as"),
-	Gtk::AccelKey(keybindings_.config_
+	Gtk::AccelKey(keybindings.config_
 		      .key_map()["save_as"]),
 	[this]() {
 	  SaveFileAs();
 	});
 
-  keybindings_.
+  keybindings.
     action_group_menu()->
     add(Gtk::Action::create("FileSave",
 			    "Save"),
-	Gtk::AccelKey(keybindings_.config_
+	Gtk::AccelKey(keybindings.config_
 		      .key_map()["save"]),
 	[this]() {
 	  SaveFile();
 	});
   
-  keybindings_.
+  keybindings.
     action_group_menu()->
     add(Gtk::Action::create("ProjectCompileAndRun",
 			    "Compile And Run"),
-	Gtk::AccelKey(keybindings_.config_
+	Gtk::AccelKey(keybindings.config_
 		      .key_map()["compile_and_run"]),
 	[this]() {
 	  SaveFile();
@@ -83,11 +82,11 @@ Window::Window() :
 	  }
 	});
    
-  keybindings_.
+  keybindings.
     action_group_menu()->
     add(Gtk::Action::create("ProjectCompile",
                             "Compile"),
-        Gtk::AccelKey(keybindings_.config_
+        Gtk::AccelKey(keybindings.config_
                       .key_map()["compile"]),
         [this]() {
           SaveFile();
@@ -106,11 +105,11 @@ Window::Window() :
           }
         });
 
-  add_accel_group(keybindings_.ui_manager_menu()->get_accel_group());
-  add_accel_group(keybindings_.ui_manager_hidden()->get_accel_group());
-  keybindings_.BuildMenu();
+  add_accel_group(keybindings.ui_manager_menu()->get_accel_group());
+  add_accel_group(keybindings.ui_manager_hidden()->get_accel_group());
+  keybindings.BuildMenu();
 
-  window_box_.pack_start(menu_.view(), Gtk::PACK_SHRINK);
+  window_box_.pack_start(menu.view(), Gtk::PACK_SHRINK);
 
   window_box_.pack_start(notebook.entry, Gtk::PACK_SHRINK);
   paned_.set_position(300);

--- a/juci/window.cc
+++ b/juci/window.cc
@@ -14,7 +14,7 @@ Window::Window() :
   INFO("Create Window");
   set_title("juCi++");
   set_default_size(600, 400);
-  set_events(Gdk::POINTER_MOTION_MASK);
+  set_events(Gdk::POINTER_MOTION_MASK|Gdk::FOCUS_CHANGE_MASK);
   add(window_box_);
   keybindings_.action_group_menu()->add(Gtk::Action::create("FileQuit",
                                                             "Quit juCi++"),

--- a/juci/window.h
+++ b/juci/window.h
@@ -10,19 +10,17 @@
 class Window : public Gtk::Window {
 public:
   Window();
-  MainConfig& main_config() { return main_config_; }
   // std::string  OnSaveFileAs();
   Gtk::Box window_box_;
   virtual ~Window() { }
 
-  MainConfig main_config_;
-  Keybindings::Controller keybindings_;
-  Menu::Controller menu_;
+  MainConfig main_config;
+  Keybindings::Controller keybindings;
+  Menu::Controller menu;
   Notebook::Controller notebook;
   Terminal::Controller terminal;
-  PluginApi api_;
-  
-  Keybindings::Controller& keybindings() { return keybindings_; }
+  PluginApi api;
+
  private:
   std::mutex running;
   Gtk::VPaned paned_;


### PR DESCRIPTION
Had to create a better tooltip-class, the one from gtk was pretty bad. The warning and error messages are maybe a bit eager (based on mouse and text-cursor), but one can maybe add options for that in the future. 

One could also use the Tooltips class to add tooltips for parameters of class functions after completion. 