### PR TITLE
Many bug fixes and improved clang indentation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -std=c++11 -pthread -Wall -Wno-reord
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/")
 
 if(APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -L/usr/local/opt/gettext/lib -I/usr/local/opt/gettext/include -undefined dynamic_lookup") #T
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -undefined dynamic_lookup")
+  link_directories(/usr/local/lib /usr/local/opt/gettext/lib)
+  include_directories(/usr/local/opt/gettext/include)
   set(CMAKE_MACOSX_RPATH 1)
   set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig")
 endif()

--- a/src/directories.cc
+++ b/src/directories.cc
@@ -68,6 +68,7 @@ Directories::Directories() : stop_update_thread(false) {
   });
   
   update_dispatcher.connect([this](){
+    DEBUG("start");
     update_mutex.lock();
     for(auto &path: update_paths) {
       if(last_write_times.count(path)>0)
@@ -75,11 +76,13 @@ Directories::Directories() : stop_update_thread(false) {
     }
     update_paths.clear();
     update_mutex.unlock();
+    DEBUG("end");
   });
   
   update_thread=std::thread([this](){
     while(!stop_update_thread) {
       std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+      DEBUG("start");
       update_mutex.lock();
       if(update_paths.size()==0) {
         for(auto it=last_write_times.begin();it!=last_write_times.end();) {
@@ -101,6 +104,7 @@ Directories::Directories() : stop_update_thread(false) {
           update_dispatcher();
       }
       update_mutex.unlock();
+      DEBUG("end");
     }
   });
 }
@@ -138,14 +142,17 @@ void Directories::open(const boost::filesystem::path& dir_path) {
 }
 
 void Directories::update() {
+  DEBUG("start");
   update_mutex.lock();
   for(auto &last_write_time: last_write_times) {
     add_path(last_write_time.first, last_write_time.second.first);
   }
   update_mutex.unlock();
+  DEBUG("end");
 }
 
 void Directories::select(const boost::filesystem::path &path) {
+  DEBUG("start");
   if(current_path=="")
     return;
     
@@ -185,6 +192,7 @@ void Directories::select(const boost::filesystem::path &path) {
     }
     return false;
   });
+  DEBUG("end");
 }
 
 bool Directories::ignored(std::string path) {
@@ -204,6 +212,7 @@ bool Directories::ignored(std::string path) {
 }
 
 void Directories::add_path(const boost::filesystem::path& dir_path, const Gtk::TreeModel::Row &parent) {
+  DEBUG("start");
   last_write_times[dir_path.string()]={parent, boost::filesystem::last_write_time(dir_path)};
   std::unique_ptr<Gtk::TreeNodeChildren> children; //Gtk::TreeNodeChildren is missing default constructor...
   if(parent)
@@ -257,4 +266,5 @@ void Directories::add_path(const boost::filesystem::path& dir_path, const Gtk::T
     auto child=tree_store->append(*children);
     child->set_value(column_record.name, std::string("(empty)"));
   }
+  DEBUG("end");
 }

--- a/src/juci.cc
+++ b/src/juci.cc
@@ -6,9 +6,9 @@
 using namespace std; //TODO: remove
 
 void init_logging() {
-  add_common_attributes();
-  add_file_log(keywords::file_name = Singleton::log_dir() + "juci.log",
-               keywords::auto_flush = true);
+  boost::log::add_common_attributes();
+  boost::log::add_file_log(boost::log::keywords::file_name = Singleton::log_dir() + "juci.log",
+               boost::log::keywords::auto_flush = true);
   INFO("Logging initalized");
 }
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -10,8 +10,6 @@
 #include <boost/log/sources/severity_logger.hpp>
 #include <boost/log/sources/record_ostream.hpp>
 
-using namespace boost::log;
-
 #define TRACE_VAR(x) BOOST_LOG_TRIVIAL(trace)      << "** Trace: "   << __FILE__ << "@" << __func__ << "(" << __LINE__ << "): " << #x << "=<" << x << ">";
 #define DEBUG_VAR(x) BOOST_LOG_TRIVIAL(debug)      << "** Debug: "   << __FILE__ << "@" << __func__ << "(" << __LINE__ << "): " << #x << "=<" << x << ">";
 #define INFO_VAR(x) BOOST_LOG_TRIVIAL(info)        << "** Info: "    << __FILE__ << "@" << __func__ << "(" << __LINE__ << "): " << #x << "=<" << x << ">";

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -1,8 +1,7 @@
 #include "menu.h"
-#include "logging.h"
+#include <iostream>
 
 Menu::Menu() : box(Gtk::ORIENTATION_VERTICAL) {
-  INFO("Creating menu");
   action_group = Gtk::ActionGroup::create();
   ui_manager = Gtk::UIManager::create();
 
@@ -15,7 +14,6 @@ Menu::Menu() : box(Gtk::ORIENTATION_VERTICAL) {
   action_group->add(Gtk::Action::create("SourceMenu", "_Source"));
   action_group->add(Gtk::Action::create("PluginMenu", "_Plugins"));
   action_group->add(Gtk::Action::create("HelpMenu", "Help"));
-  INFO("Menu created");
 }
 
 Gtk::Widget& Menu::get_widget() {

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -190,6 +190,7 @@ bool Notebook::close_current_page() {
 
 bool Notebook::save_modified_dialog() {
   Gtk::MessageDialog dialog((Gtk::Window&)(*get_toplevel()), "Save file!", false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO);
+  dialog.set_default_response(Gtk::RESPONSE_YES);
   dialog.set_secondary_text("Do you want to save: " + get_current_view()->file_path.string()+" ?");
   int result = dialog.run();
   if(result==Gtk::RESPONSE_YES) {

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -145,7 +145,7 @@ bool Notebook::save(int page, bool reparse_needed) {
                 if(source_clang_view->restart_parse())
                   Singleton::terminal()->async_print("Reparsing "+source_clang_view->file_path.string()+"\n");
                 else
-                  Singleton::terminal()->async_print("Already reparsing "+source_clang_view->file_path.string()+". Please reopen the file manually.\n");
+                  Singleton::terminal()->async_print("Error: failed to reparse "+source_clang_view->file_path.string()+". Please reopen the file manually.\n");
               }
             }
           }

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -172,8 +172,6 @@ bool Notebook::close_current_page() {
     }
     int page = get_current_page();
     remove_page(page);
-    if(get_current_page()==-1)
-      Singleton::status()->set_text("");
     auto source_view=source_views.at(page);
     if(auto source_clang_view=dynamic_cast<Source::ClangView*>(source_view))
       source_clang_view->async_delete();

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -32,13 +32,11 @@ Source::View* Notebook::get_view(int page) {
 }
 
 Source::View* Notebook::get_current_view() {
-  INFO("Getting sourceview");
   return get_view(get_current_page());
 }
 
 void Notebook::open(const boost::filesystem::path &file_path) {
-  INFO("Notebook open file");
-  INFO("Notebook create page");
+  DEBUG("start");
   for(int c=0;c<size();c++) {
     if(file_path==get_view(c)->file_path) {
       set_current_page(c);
@@ -106,14 +104,16 @@ void Notebook::open(const boost::filesystem::path &file_path) {
   get_current_view()->on_update_status=[this](Source::View* view, const std::string &status) {
     if(get_current_page()!=-1 && get_current_view()==view)
       Singleton::status()->set_text(status);
-    else
-      Singleton::status()->set_text("");
   };
+  DEBUG("end");
 }
 
 bool Notebook::save(int page) {
-  if(page>=size())
+  DEBUG("start");
+  if(page>=size()) {
+    DEBUG("end false");
     return false;
+  }
   auto view=get_view(page);
   if (view->file_path != "" && view->get_buffer()->get_modified()) {
     if(juci::filesystem::write(view->file_path, view->get_buffer())) {
@@ -145,16 +145,16 @@ bool Notebook::save(int page) {
           }
         }
       }
-      
+      DEBUG("end true");
       return true;
     }
     Singleton::terminal()->print("Error: could not save file " +view->file_path.string()+"\n");
   }
+  DEBUG("end false");
   return false;
 }
 
 bool Notebook::save_current() {
-  INFO("Notebook save current file");
   if(get_current_page()==-1)
     return false;
   return save(get_current_page());
@@ -162,7 +162,6 @@ bool Notebook::save_current() {
 
 bool Notebook::close_current_page() {
   DEBUG("start");
-  INFO("Notebook close page");
   if (get_current_page()!=-1) {
     if(get_current_view()->get_buffer()->get_modified()){
       if(!save_modified_dialog()) {
@@ -186,7 +185,6 @@ bool Notebook::close_current_page() {
 }
 
 bool Notebook::save_modified_dialog() {
-  INFO("Notebook::save_modified_dialog");
   Gtk::MessageDialog dialog((Gtk::Window&)(*get_toplevel()), "Save file!", false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO);
   dialog.set_secondary_text("Do you want to save: " + get_current_view()->file_path.string()+" ?");
   int result = dialog.run();

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -104,8 +104,10 @@ void Notebook::open(const boost::filesystem::path &file_path) {
   });
   
   get_current_view()->on_update_status=[this](Source::View* view, const std::string &status) {
-    if(get_current_view()==view)
+    if(get_current_page()!=-1 && get_current_view()==view)
       Singleton::status()->set_text(status);
+    else
+      Singleton::status()->set_text("");
   };
 }
 

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -28,15 +28,11 @@ int Notebook::size() {
 }
 
 Source::View* Notebook::get_view(int page) {
-  if(page>=size())
-    return nullptr;
   return source_views.at(page);
 }
 
 Source::View* Notebook::get_current_view() {
   INFO("Getting sourceview");
-  if(get_current_page()==-1)
-    return nullptr;
   return get_view(get_current_page());
 }
 
@@ -163,25 +159,29 @@ bool Notebook::save_current() {
 }
 
 bool Notebook::close_current_page() {
+  DEBUG("start");
   INFO("Notebook close page");
-  if (size() != 0) {
+  if (get_current_page()!=-1) {
     if(get_current_view()->get_buffer()->get_modified()){
-      if(!save_modified_dialog())
+      if(!save_modified_dialog()) {
+        DEBUG("end false");
         return false;
+      }
     }
     int page = get_current_page();
     remove_page(page);
     if(get_current_page()==-1)
       Singleton::status()->set_text("");
     auto source_view=source_views.at(page);
-    source_views.erase(source_views.begin()+ page);
-    scrolled_windows.erase(scrolled_windows.begin()+page);
-    hboxes.erase(hboxes.begin()+page);
     if(auto source_clang_view=dynamic_cast<Source::ClangView*>(source_view))
       source_clang_view->async_delete();
     else
       delete source_view;
+    source_views.erase(source_views.begin()+ page);
+    scrolled_windows.erase(scrolled_windows.begin()+page);
+    hboxes.erase(hboxes.begin()+page);
   }
+  DEBUG("end true");
   return true;
 }
 

--- a/src/notebook.h
+++ b/src/notebook.h
@@ -18,7 +18,7 @@ public:
   Source::View* get_current_view();
   bool close_current_page();
   void open(const boost::filesystem::path &file_path);
-  bool save(int page);
+  bool save(int page, bool reparse_needed=false);
   bool save_current();
       
 private:

--- a/src/selectiondialog.cc
+++ b/src/selectiondialog.cc
@@ -117,7 +117,6 @@ void SelectionDialogBase::update_tooltips() {
 }
 
 void SelectionDialogBase::move() {
-  INFO("SelectionDialog set position");
   Gdk::Rectangle rectangle;
   text_view.get_iter_location(start_mark->get_iter(), rectangle);
   int buffer_x=rectangle.get_x();
@@ -130,8 +129,6 @@ void SelectionDialogBase::move() {
 }
 
 void SelectionDialogBase::resize() {
-  INFO("SelectionDialog set size");
-  
   if(list_view_text.get_realized()) {
     int row_width=0, row_height;
     Gdk::Rectangle rect;

--- a/src/selectiondialog.cc
+++ b/src/selectiondialog.cc
@@ -210,7 +210,8 @@ void SelectionDialog::show() {
         else {
           auto last_it=list_view_text.get_model()->children().end();
           last_it--;
-          list_view_text.set_cursor(list_view_text.get_model()->get_path(last_it));
+          if(last_it)
+            list_view_text.set_cursor(list_view_text.get_model()->get_path(last_it));
         }
         return true;
       }
@@ -269,7 +270,8 @@ bool SelectionDialog::on_key_press(GdkEventKey* key) {
     else {
       auto last_it=list_view_text.get_model()->children().end();
       last_it--;
-      list_view_text.set_cursor(list_view_text.get_model()->get_path(last_it));
+      if(last_it)
+        list_view_text.set_cursor(list_view_text.get_model()->get_path(last_it));
     }
     return true;
   }
@@ -418,7 +420,8 @@ bool CompletionDialog::on_key_press(GdkEventKey* key) {
     else {
       auto last_it=list_view_text.get_model()->children().end();
       last_it--;
-      list_view_text.set_cursor(list_view_text.get_model()->get_path(last_it));
+      if(last_it)
+        list_view_text.set_cursor(list_view_text.get_model()->get_path(last_it));
     }
     select(false);
     update_tooltips();

--- a/src/source.cc
+++ b/src/source.cc
@@ -660,20 +660,19 @@ bool Source::View::on_key_press_event(GdkEventKey* key) {
 bool Source::View::on_button_press_event(GdkEventButton *event) {
   if(event->type==GDK_2BUTTON_PRESS) {
     Gtk::TextIter start, end;
-    if(get_buffer()->get_selection_bounds(start, end)) {
-      auto iter=start;
-      while((*iter>=48 && *iter<=57) || (*iter>=65 && *iter<=90) || (*iter>=97 && *iter<=122) || *iter==95) {
-        start=iter;
-        if(!iter.backward_char())
-          break;
-      }
-      while((*end>=48 && *end<=57) || (*end>=65 && *end<=90) || (*end>=97 && *end<=122) || *end==95) {
-        if(!end.forward_char())
-          break;
-      }
-      get_buffer()->select_range(start, end);
-      return true;
+    get_buffer()->get_selection_bounds(start, end);
+    auto iter=start;
+    while((*iter>=48 && *iter<=57) || (*iter>=65 && *iter<=90) || (*iter>=97 && *iter<=122) || *iter==95) {
+      start=iter;
+      if(!iter.backward_char())
+        break;
     }
+    while((*end>=48 && *end<=57) || (*end>=65 && *end<=90) || (*end>=97 && *end<=122) || *end==95) {
+      if(!end.forward_char())
+        break;
+    }
+    get_buffer()->select_range(start, end);
+    return true;
   }
   
   return Gsv::View::on_button_press_event(event);

--- a/src/source.cc
+++ b/src/source.cc
@@ -703,7 +703,7 @@ bool Source::View::on_button_press_event(GdkEventButton *event) {
 }
 
 std::pair<char, unsigned> Source::View::find_tab_char_and_size() {
-  const std::regex indent_regex("^([ \t]+).*$");
+  const std::regex indent_regex("^([ \t]+)(.*)$");
   auto size=get_buffer()->get_line_count();
   std::unordered_map<char, size_t> tab_chars;
   std::unordered_map<unsigned, size_t> tab_sizes;
@@ -711,28 +711,36 @@ std::pair<char, unsigned> Source::View::find_tab_char_and_size() {
   for(int c=0;c<size;c++) {
     auto line=get_line(c);
     std::smatch sm;
+    std::string str;
     if(std::regex_match(line, sm, indent_regex)) {
-      auto str=sm[1].str();
-      
-      long tab_diff=abs(static_cast<long>(str.size()-last_tab_size));
-      if(tab_diff>0) {
-        unsigned tab_diff_unsigned=static_cast<unsigned>(tab_diff);
-        auto it_size=tab_sizes.find(tab_diff_unsigned);
-        if(it_size!=tab_sizes.end())
-          it_size->second++;
-        else
-          tab_sizes[tab_diff_unsigned]=1;
-      }
-      
-      last_tab_size=str.size();
-      
-      if(str.size()>0) {
-        auto it_char=tab_chars.find(str[0]);
-        if(it_char!=tab_chars.end())
-          it_char->second++;
-        else
-          tab_chars[str[0]]=1;
-      }
+      if(sm[2].str().size()==0)
+        continue;
+      str=sm[1].str();
+    }
+    else {
+      str="";
+      if(line.size()==0)
+        continue;
+    }
+    
+    long tab_diff=abs(static_cast<long>(str.size()-last_tab_size));
+    if(tab_diff>0) {
+      unsigned tab_diff_unsigned=static_cast<unsigned>(tab_diff);
+      auto it_size=tab_sizes.find(tab_diff_unsigned);
+      if(it_size!=tab_sizes.end())
+        it_size->second++;
+      else
+        tab_sizes[tab_diff_unsigned]=1;
+    }
+    
+    last_tab_size=str.size();
+    
+    if(str.size()>0) {
+      auto it_char=tab_chars.find(str[0]);
+      if(it_char!=tab_chars.end())
+        it_char->second++;
+      else
+        tab_chars[str[0]]=1;
     }
   }
   char found_tab_char=0;

--- a/src/source.cc
+++ b/src/source.cc
@@ -195,7 +195,7 @@ Source::View::View(const boost::filesystem::path &file_path): file_path(file_pat
         if(backward_success) {
           if((spellcheck_all && !get_source_buffer()->iter_has_context_class(context_iter, "no-spell-check")) || get_source_buffer()->iter_has_context_class(context_iter, "comment") || get_source_buffer()->iter_has_context_class(context_iter, "string")) {
             if(last_keyval_is_backspace && !is_word_iter(iter) && iter.forward_char()) {} //backspace fix
-            if(*iter==32 || *iter==45) { //Might have used space or - to split two words
+            if(!is_word_iter(iter)) { //Might have used space or - to split two words
               auto first=iter;
               auto second=iter;
               if(first.backward_char() && second.forward_char()) {
@@ -1641,6 +1641,7 @@ void Source::ClangView::async_delete() {
 
 bool Source::ClangView::restart_parse() {
   if(!restart_parse_running) {
+    start_reparse_needed=false;
     restart_parse_running=true;
     parse_thread_stop=true;
     if(restart_parse_thread.joinable())

--- a/src/source.cc
+++ b/src/source.cc
@@ -1245,7 +1245,6 @@ bool Source::ClangViewAutocomplete::on_key_press_event(GdkEventKey *key) {
 void Source::ClangViewAutocomplete::start_autocomplete() {
   if(!has_focus())
     return;
-  cout << (int)last_keyval << endl;
   if(!((last_keyval>='0' && last_keyval<='9') || 
        (last_keyval>='a' && last_keyval<='z') || (last_keyval>='A' && last_keyval<='Z') ||
        last_keyval=='_' || last_keyval==127 || last_keyval=='.' || last_keyval==':')) {

--- a/src/source.cc
+++ b/src/source.cc
@@ -572,6 +572,8 @@ bool Source::View::find_start_of_closed_expression(Gtk::TextIter iter, Gtk::Text
       }
     }
     if(iter.starts_line() && count1<=0 && count2<=0) {
+      auto insert_iter=get_buffer()->get_insert()->get_iter();
+      while(iter!=insert_iter && *iter==tab_char && iter.forward_char()) {}
       found_iter=iter;
       return true;
     }
@@ -1248,7 +1250,7 @@ bool Source::ClangViewParse::on_key_press_event(GdkEventKey* key) {
     auto iter=get_buffer()->get_insert()->get_iter();
     Gtk::TextIter start_of_sentence_iter;
     if(find_start_of_closed_expression(iter, start_of_sentence_iter)) {
-      auto start_line=get_line(start_of_sentence_iter);
+      auto start_line=get_line_before(start_of_sentence_iter);
       std::smatch sm;
       std::string tabs;
       if(std::regex_match(start_line, sm, tabs_regex)) {

--- a/src/source.cc
+++ b/src/source.cc
@@ -52,7 +52,7 @@ Source::View::View(const boost::filesystem::path &file_path): file_path(file_pat
   set_smart_home_end(Gsv::SMART_HOME_END_BEFORE);
   get_source_buffer()->begin_not_undoable_action();
   if(juci::filesystem::read(file_path, get_buffer())==-1)
-    Singleton::terminal()->print("Warning: "+file_path.string()+" is not a valid UTF-8 file. Saving might corrupt the file.\n", true);
+    Singleton::terminal()->print("Error: "+file_path.string()+" is not a valid UTF-8 file.");
   get_source_buffer()->end_not_undoable_action();
   get_buffer()->place_cursor(get_buffer()->get_iter_at_offset(0)); 
   search_settings = gtk_source_search_settings_new();

--- a/src/source.cc
+++ b/src/source.cc
@@ -1774,7 +1774,7 @@ void Source::ClangView::async_delete() {
 
 bool Source::ClangView::restart_parse() {
   if(!restart_parse_running) {
-    start_reparse_needed=false;
+    reparse_needed=false;
     restart_parse_running=true;
     parse_thread_stop=true;
     if(restart_parse_thread.joinable())

--- a/src/source.cc
+++ b/src/source.cc
@@ -405,24 +405,16 @@ void Source::View::replace_all(const std::string &replacement) {
 
 void Source::View::paste() {
   auto text=Gtk::Clipboard::get()->wait_for_text();
-  //remove carriage returns (which makes clang return wrong line index)
-  for(auto it=text.begin();it!=text.end();) {
+  //replace stand-alone carriage returns (which makes clang return wrong line index) with newlines
+  for(auto it=text.begin();it!=text.end();it++) {
     if(*it=='\r') {
       auto it2=it;
       it2++;
-      if(it2!=text.end()) {
-        if(*it2=='\n')
-          it=text.erase(it);
-        else {
+      if(it2!=text.end() && *it2!='\n')
           text.replace(it, it2, "\n");
-          it++;
-        }
-      }
       else
-        it=text.erase(it);
+        text.replace(it, it2, "\n");
     }
-    else
-      it++;
   }
 
   auto line=get_line_before();

--- a/src/source.cc
+++ b/src/source.cc
@@ -1021,11 +1021,11 @@ void Source::ClangViewParse::update_diagnostics() {
       }
       auto end_line=get_line(diagnostic.offsets.second.line-1); //index is sometimes off the line
       auto end_line_index=diagnostic.offsets.second.index-1;
-      if(end_line_index>=end_line.size()) {
+      if(end_line_index>end_line.size()) {
         if(end_line.size()==0)
           end_line_index=0;
         else
-          end_line_index=end_line.size()-1;
+          end_line_index=end_line.size();
       }
       auto start=get_buffer()->get_iter_at_line_index(diagnostic.offsets.first.line-1, start_line_index);
       auto end=get_buffer()->get_iter_at_line_index(diagnostic.offsets.second.line-1, end_line_index);

--- a/src/source.cc
+++ b/src/source.cc
@@ -410,9 +410,7 @@ void Source::View::paste() {
     if(*it=='\r') {
       auto it2=it;
       it2++;
-      if(it2!=text.end() && *it2!='\n')
-          text.replace(it, it2, "\n");
-      else
+      if(it2==text.end() || *it2!='\n')
         text.replace(it, it2, "\n");
     }
   }

--- a/src/source.cc
+++ b/src/source.cc
@@ -584,7 +584,7 @@ bool Source::View::find_start_of_closed_expression(Gtk::TextIter iter, Gtk::Text
     }
     if(iter.starts_line() && count1<=0 && count2<=0) {
       auto insert_iter=get_buffer()->get_insert()->get_iter();
-      while(iter!=insert_iter && *iter==tab_char && iter.forward_char()) {}
+      while(iter!=insert_iter && *iter==static_cast<unsigned char>(tab_char) && iter.forward_char()) {}
       found_iter=iter;
       return true;
     }
@@ -983,6 +983,7 @@ Source::View(file_path), project_path(project_path) {
   parse_fail.connect([this](){
     Singleton::terminal()->print("Error: failed to reparse "+this->file_path.string()+".\n");
     set_status("");
+    parsing_in_progress->cancel("failed");
   });
   init_parse();
   

--- a/src/source.cc
+++ b/src/source.cc
@@ -545,18 +545,8 @@ std::string Source::View::get_line_before() {
 }
 
 bool Source::View::find_start_of_closed_expression(Gtk::TextIter iter, Gtk::TextIter &found_iter) {
-  do {
-    if(*iter!='{' && *iter!=' ' && *iter!='\t')
-      break;
-    if(iter.starts_line()) {
-      found_iter=iter;
-      return true;
-    }
-  } while(iter.backward_char());
-  
   int count1=0;
   int count2=0;
-  int count3=0;
   
   bool ignore=false;
   
@@ -575,17 +565,13 @@ bool Source::View::find_start_of_closed_expression(Gtk::TextIter iter, Gtk::Text
           count1++;
         else if(*iter==']')
           count2++;
-        else if(*iter=='}')
-          count3++;
         else if(*iter=='(')
           count1--;
         else if(*iter=='[')
           count2--;
-        else if(*iter=='{')
-          count3--;
       }
     }
-    if(iter.starts_line() && count1<=0 && count2<=0 && count3<=0) {
+    if(iter.starts_line() && count1<=0 && count2<=0) {
       found_iter=iter;
       return true;
     }

--- a/src/source.cc
+++ b/src/source.cc
@@ -186,25 +186,23 @@ Source::View::View(const boost::filesystem::path &file_path): file_path(file_pat
       delayed_spellcheck_suggestions_connection.disconnect();
       
       auto iter=get_buffer()->get_insert()->get_iter();
-      if(last_keyval_is_backspace || iter.backward_char()) {
-        auto context_iter=iter;
-        if(context_iter.backward_char()) {
-          if((spellcheck_all && !get_source_buffer()->iter_has_context_class(context_iter, "no-spell-check")) || get_source_buffer()->iter_has_context_class(context_iter, "comment") || get_source_buffer()->iter_has_context_class(context_iter, "string")) {
-            if(*iter==32 || *iter==45) { //Might have used space or - to split two words
-              auto first=iter;
-              auto second=iter;
-              if(first.backward_char() && second.forward_char()) {
-                get_buffer()->remove_tag_by_name("spellcheck_error", first, second);
-                auto word=spellcheck_get_word(first);
-                spellcheck_word(word.first, word.second);
-                word=spellcheck_get_word(second);
-                spellcheck_word(word.first, word.second);
-              }
-            }
-            else {
-              auto word=spellcheck_get_word(iter);
+      auto context_iter=iter;
+      if(((last_keyval_is_backspace && !iter.ends_line()) || iter.backward_char()) && context_iter.backward_char() && context_iter.backward_char()) {
+        if((spellcheck_all && !get_source_buffer()->iter_has_context_class(context_iter, "no-spell-check")) || get_source_buffer()->iter_has_context_class(context_iter, "comment") || get_source_buffer()->iter_has_context_class(context_iter, "string")) {
+          if(*iter==32 || *iter==45) { //Might have used space or - to split two words
+            auto first=iter;
+            auto second=iter;
+            if(first.backward_char() && second.forward_char()) {
+              get_buffer()->remove_tag_by_name("spellcheck_error", first, second);
+              auto word=spellcheck_get_word(first);
+              spellcheck_word(word.first, word.second);
+              word=spellcheck_get_word(second);
               spellcheck_word(word.first, word.second);
             }
+          }
+          else {
+            auto word=spellcheck_get_word(iter);
+            spellcheck_word(word.first, word.second);
           }
         }
       }
@@ -701,16 +699,20 @@ std::pair<char, unsigned> Source::View::find_tab_char_and_size() {
   return {found_tab_char, found_tab_size};
 }
 
+bool Source::View::is_word_iter(const Gtk::TextIter& iter) {
+  return ((*iter>=48 && *iter<=57) || (*iter>=65 && *iter<=90) || (*iter>=97 && *iter<=122) || *iter==39 || *iter>=128);
+}
+
 std::pair<Gtk::TextIter, Gtk::TextIter> Source::View::spellcheck_get_word(Gtk::TextIter iter) {
   auto start=iter;
   auto end=iter;
   
-  while((*iter>=48 && *iter<=57) || (*iter>=65 && *iter<=90) || (*iter>=97 && *iter<=122) || *iter==39 || *iter>=128) {
+  while(is_word_iter(iter)) {
     start=iter;
     if(!iter.backward_char())
       break;
   }
-  while((*end>=48 && *end<=57) || (*end>=65 && *end<=90) || (*end>=97 && *end<=122) || *iter==39 || *end>=128) {
+  while(is_word_iter(end)) {
     if(!end.forward_char())
       break;
   }

--- a/src/source.cc
+++ b/src/source.cc
@@ -51,8 +51,8 @@ AspellConfig* Source::View::spellcheck_config=NULL;
 Source::View::View(const boost::filesystem::path &file_path): file_path(file_path) {
   set_smart_home_end(Gsv::SMART_HOME_END_BEFORE);
   get_source_buffer()->begin_not_undoable_action();
-  if(!juci::filesystem::read(file_path, get_buffer()))
-    Singleton::terminal()->print("Error: "+file_path.string()+" is not a valid UTF-8 file.\n");
+  if(juci::filesystem::read(file_path, get_buffer())==-1)
+    Singleton::terminal()->print("Warning: "+file_path.string()+" is not a valid UTF-8 file. Saving might corrupt the file.\n", true);
   get_source_buffer()->end_not_undoable_action();
   get_buffer()->place_cursor(get_buffer()->get_iter_at_offset(0)); 
   search_settings = gtk_source_search_settings_new();

--- a/src/source.cc
+++ b/src/source.cc
@@ -1022,11 +1022,11 @@ void Source::ClangViewParse::update_diagnostics() {
     if(diagnostic.path==file_path.string()) {
       auto start_line=get_line(diagnostic.offsets.first.line-1); //index is sometimes off the line
       auto start_line_index=diagnostic.offsets.first.index-1;
-      if(start_line_index>start_line.size()) {
+      if(start_line_index>=start_line.size()) {
         if(start_line.size()==0)
           start_line_index=0;
         else
-          start_line_index=start_line.size();
+          start_line_index=start_line.size()-1;
       }
       auto end_line=get_line(diagnostic.offsets.second.line-1); //index is sometimes off the line
       auto end_line_index=diagnostic.offsets.second.index-1;
@@ -1055,6 +1055,12 @@ void Source::ClangViewParse::update_diagnostics() {
       diagnostic_tooltips.emplace_back(create_tooltip_buffer, *this, get_buffer()->create_mark(start), get_buffer()->create_mark(end));
     
       get_buffer()->apply_tag_by_name(diagnostic_tag_name+"_underline", start, end);
+      auto iter=get_buffer()->get_insert()->get_iter();
+      if(iter.ends_line()) {
+        auto next_iter=iter;
+        if(next_iter.forward_char())
+          get_buffer()->remove_tag_by_name(diagnostic_tag_name+"_underline", iter, next_iter);
+      }
     }
   }
 }

--- a/src/source.cc
+++ b/src/source.cc
@@ -198,7 +198,7 @@ Source::View::View(const boost::filesystem::path &file_path): file_path(file_pat
             if(!is_word_iter(iter)) { //Might have used space or - to split two words
               auto first=iter;
               auto second=iter;
-              if(first.backward_char() && second.forward_char()) {
+              if(first.backward_char() && second.forward_char() && !second.starts_line()) {
                 get_buffer()->remove_tag_by_name("spellcheck_error", first, second);
                 auto word=spellcheck_get_word(first);
                 spellcheck_word(word.first, word.second);

--- a/src/source.cc
+++ b/src/source.cc
@@ -1287,17 +1287,13 @@ Source::ClangViewParse(file_path, project_path), autocomplete_cancel_starting(fa
   get_buffer()->signal_mark_set().connect([this](const Gtk::TextBuffer::iterator& iterator, const Glib::RefPtr<Gtk::TextBuffer::Mark>& mark){
     if(mark->get_name()=="insert") {
       autocomplete_cancel_starting=true;
-      if(completion_dialog_shown) {
+      if(completion_dialog_shown)
         completion_dialog->hide();
-        start_reparse();
-      }
     }
   });
   signal_scroll_event().connect([this](GdkEventScroll* event){
-    if(completion_dialog_shown) {
+    if(completion_dialog_shown)
       completion_dialog->hide();
-      start_reparse();
-    }
     return false;
   }, false);
   signal_key_release_event().connect([this](GdkEventKey* key){
@@ -1311,10 +1307,8 @@ Source::ClangViewParse(file_path, project_path), autocomplete_cancel_starting(fa
 
   signal_focus_out_event().connect([this](GdkEventFocus* event) {
     autocomplete_cancel_starting=true;
-    if(completion_dialog_shown) {
+    if(completion_dialog_shown)
       completion_dialog->hide();
-      start_reparse();
-    }
       
     return false;
   });
@@ -1439,6 +1433,7 @@ void Source::ClangViewAutocomplete::autocomplete() {
       }
       else {
         set_status("");
+        start_reparse();
         start_autocomplete();
       }
     });

--- a/src/source.cc
+++ b/src/source.cc
@@ -404,104 +404,125 @@ void Source::View::replace_all(const std::string &replacement) {
 }
 
 void Source::View::paste() {
-  Gtk::Clipboard::get()->request_text([this](const Glib::ustring& text){
-    auto line=get_line_before();
-    std::smatch sm;
-    std::string prefix_tabs;
-    if(!get_buffer()->get_has_selection() && std::regex_match(line, sm, tabs_regex) && sm[2].str().size()==0) {
-      prefix_tabs=sm[1].str();
-
-      Glib::ustring::size_type start_line=0;
-      Glib::ustring::size_type end_line=0;
-      bool paste_line=false;
-      bool first_paste_line=true;
-      size_t paste_line_tabs=-1;
-      bool first_paste_line_has_tabs=false;
-      for(Glib::ustring::size_type c=0;c<text.size();c++) {;
-        if(text[c]=='\n') {
-          end_line=c;
-          paste_line=true;
-        }
-        else if(c==text.size()-1) {
-          end_line=c+1;
-          paste_line=true;
-        }
-        if(paste_line) {
-          bool empty_line=true;
-          std::string line=text.substr(start_line, end_line-start_line);
-          size_t tabs=0;
-          for(auto chr: line) {
-            if(chr==tab_char)
-              tabs++;
-            else {
-              empty_line=false;
-              break;
-            }
-          }
-          if(first_paste_line) {
-            if(tabs!=0) {
-              first_paste_line_has_tabs=true;
-              paste_line_tabs=tabs;
-            }
-            first_paste_line=false;
-          }
-          else if(!empty_line)
-            paste_line_tabs=std::min(paste_line_tabs, tabs);
-
-          start_line=end_line+1;
-          paste_line=false;
+  auto text=Gtk::Clipboard::get()->wait_for_text();
+  //remove carriage returns (which makes clang return wrong line index)
+  for(auto it=text.begin();it!=text.end();) {
+    if(*it=='\r') {
+      auto it2=it;
+      it2++;
+      if(it2!=text.end()) {
+        if(*it2=='\n')
+          it=text.erase(it);
+        else {
+          text.replace(it, it2, "\n");
+          it++;
         }
       }
-      if(paste_line_tabs==(size_t)-1)
-        paste_line_tabs=0;
-      start_line=0;
-      end_line=0;
-      paste_line=false;
-      first_paste_line=true;
-      get_source_buffer()->begin_user_action();
-      for(Glib::ustring::size_type c=0;c<text.size();c++) {
-        if(text[c]=='\n') {
-          end_line=c;
-          paste_line=true;
-        }
-        else if(c==text.size()-1) {
-          end_line=c+1;
-          paste_line=true;
-        }
-        if(paste_line) {
-          std::string line=text.substr(start_line, end_line-start_line);
-          size_t line_tabs=0;
-          for(auto chr: line) {
-            if(chr==tab_char)
-              line_tabs++;
-            else
-              break;
-          }
-          auto tabs=paste_line_tabs;
-          if(!(first_paste_line && !first_paste_line_has_tabs) && line_tabs<paste_line_tabs) {
-            tabs=line_tabs;
-          }
-          
-          if(first_paste_line) {
-            if(first_paste_line_has_tabs)
-              get_buffer()->insert_at_cursor(text.substr(start_line+tabs, end_line-start_line-tabs));
-            else
-              get_buffer()->insert_at_cursor(text.substr(start_line, end_line-start_line));
-            first_paste_line=false;
-          }
-          else
-            get_buffer()->insert_at_cursor('\n'+prefix_tabs+text.substr(start_line+tabs, end_line-start_line-tabs));
-          start_line=end_line+1;
-          paste_line=false;
-        }
-      }
-      get_buffer()->place_cursor(get_buffer()->get_insert()->get_iter());
-      scroll_to(get_buffer()->get_insert());
-      get_source_buffer()->end_user_action();
+      else
+        it=text.erase(it);
     }
     else
-      get_buffer()->paste_clipboard(Gtk::Clipboard::get());
-  });
+      it++;
+  }
+
+  auto line=get_line_before();
+  std::smatch sm;
+  std::string prefix_tabs;
+  if(!get_buffer()->get_has_selection() && std::regex_match(line, sm, tabs_regex) && sm[2].str().size()==0) {
+    prefix_tabs=sm[1].str();
+
+    Glib::ustring::size_type start_line=0;
+    Glib::ustring::size_type end_line=0;
+    bool paste_line=false;
+    bool first_paste_line=true;
+    size_t paste_line_tabs=-1;
+    bool first_paste_line_has_tabs=false;
+    for(Glib::ustring::size_type c=0;c<text.size();c++) {;
+      if(text[c]=='\n') {
+        end_line=c;
+        paste_line=true;
+      }
+      else if(c==text.size()-1) {
+        end_line=c+1;
+        paste_line=true;
+      }
+      if(paste_line) {
+        bool empty_line=true;
+        std::string line=text.substr(start_line, end_line-start_line);
+        size_t tabs=0;
+        for(auto chr: line) {
+          if(chr==tab_char)
+            tabs++;
+          else {
+            empty_line=false;
+            break;
+          }
+        }
+        if(first_paste_line) {
+          if(tabs!=0) {
+            first_paste_line_has_tabs=true;
+            paste_line_tabs=tabs;
+          }
+          first_paste_line=false;
+        }
+        else if(!empty_line)
+          paste_line_tabs=std::min(paste_line_tabs, tabs);
+
+        start_line=end_line+1;
+        paste_line=false;
+      }
+    }
+    if(paste_line_tabs==(size_t)-1)
+      paste_line_tabs=0;
+    start_line=0;
+    end_line=0;
+    paste_line=false;
+    first_paste_line=true;
+    get_source_buffer()->begin_user_action();
+    for(Glib::ustring::size_type c=0;c<text.size();c++) {
+      if(text[c]=='\n') {
+        end_line=c;
+        paste_line=true;
+      }
+      else if(c==text.size()-1) {
+        end_line=c+1;
+        paste_line=true;
+      }
+      if(paste_line) {
+        std::string line=text.substr(start_line, end_line-start_line);
+        size_t line_tabs=0;
+        for(auto chr: line) {
+          if(chr==tab_char)
+            line_tabs++;
+          else
+            break;
+        }
+        auto tabs=paste_line_tabs;
+        if(!(first_paste_line && !first_paste_line_has_tabs) && line_tabs<paste_line_tabs) {
+          tabs=line_tabs;
+        }
+        
+        if(first_paste_line) {
+          if(first_paste_line_has_tabs)
+            get_buffer()->insert_at_cursor(text.substr(start_line+tabs, end_line-start_line-tabs));
+          else
+            get_buffer()->insert_at_cursor(text.substr(start_line, end_line-start_line));
+          first_paste_line=false;
+        }
+        else
+          get_buffer()->insert_at_cursor('\n'+prefix_tabs+text.substr(start_line+tabs, end_line-start_line-tabs));
+        start_line=end_line+1;
+        paste_line=false;
+      }
+    }
+    get_buffer()->place_cursor(get_buffer()->get_insert()->get_iter());
+    scroll_to(get_buffer()->get_insert());
+    get_source_buffer()->end_user_action();
+  }
+  else {
+    Gtk::Clipboard::get()->set_text(text);
+    get_buffer()->paste_clipboard(Gtk::Clipboard::get());
+  }
 }
 
 void Source::View::set_status(const std::string &status) {

--- a/src/source.cc
+++ b/src/source.cc
@@ -656,10 +656,6 @@ bool Source::View::find_right_bracket_forward(Gtk::TextIter iter, Gtk::TextIter 
           count++;
       }
     }
-
-    //To avoid parsing of the whole file in case of erroneous brackets 
-    if(iter.starts_line() && *iter!=tab_char && !iter.ends_line() && *iter!='#' && *iter!='p') //added p for public, private and protected keywords. 
-      return false;
   }
   return false;
 }

--- a/src/source.cc
+++ b/src/source.cc
@@ -1229,7 +1229,12 @@ Source::ClangViewParse(file_path, project_path), autocomplete_cancel_starting(fa
 }
 
 bool Source::ClangViewAutocomplete::on_key_press_event(GdkEventKey *key) {
-  last_keyval=key->keyval;
+  if(key->keyval>=32 && key->keyval<=126) {
+    if(key->keyval=='>' && last_keyval=='-')
+      last_keyval=127;
+    else
+      last_keyval=key->keyval;
+  }
   if(completion_dialog_shown) {
     if(completion_dialog->on_key_press(key))
       return true;
@@ -1240,9 +1245,10 @@ bool Source::ClangViewAutocomplete::on_key_press_event(GdkEventKey *key) {
 void Source::ClangViewAutocomplete::start_autocomplete() {
   if(!has_focus())
     return;
+  cout << (int)last_keyval << endl;
   if(!((last_keyval>='0' && last_keyval<='9') || 
        (last_keyval>='a' && last_keyval<='z') || (last_keyval>='A' && last_keyval<='Z') ||
-       last_keyval=='_' || last_keyval=='>' || last_keyval=='.' || last_keyval==':')) {
+       last_keyval=='_' || last_keyval==127 || last_keyval=='.' || last_keyval==':')) {
     autocomplete_cancel_starting=true;
     return;
   }

--- a/src/source.h
+++ b/src/source.h
@@ -138,7 +138,7 @@ namespace Source {
     ~ClangViewParse();
     boost::filesystem::path project_path;
     void start_reparse();
-    bool start_reparse_needed=false;
+    bool reparse_needed=false;
   protected:
     void init_parse();
     bool on_key_press_event(GdkEventKey* key);

--- a/src/source.h
+++ b/src/source.h
@@ -114,6 +114,7 @@ namespace Source {
     std::unique_ptr<SelectionDialog> spellcheck_suggestions_dialog;
     bool spellcheck_suggestions_dialog_shown=false;
     sigc::connection delayed_spellcheck_suggestions_connection;
+    bool last_keyval_is_backspace=false;
   };
   
   class GenericView : public View {

--- a/src/source.h
+++ b/src/source.h
@@ -90,6 +90,9 @@ namespace Source {
     std::string get_line(size_t line_number);
     std::string get_line_before_insert();
     
+    bool find_start_of_sentence(Gtk::TextIter iter, Gtk::TextIter &found_iter);
+    bool find_right_bracket_forward(Gtk::TextIter iter, Gtk::TextIter &found_iter);
+    
     bool on_key_press_event(GdkEventKey* key);
     bool on_button_press_event(GdkEventButton *event);
     
@@ -104,7 +107,7 @@ namespace Source {
     GtkSourceSearchContext *search_context;
     GtkSourceSearchSettings *search_settings;
     static void search_occurrences_updated(GtkWidget* widget, GParamSpec* property, gpointer data);
-    
+        
     static AspellConfig* spellcheck_config;
     AspellCanHaveError *spellcheck_possible_err;
     AspellSpeller *spellcheck_checker;

--- a/src/source.h
+++ b/src/source.h
@@ -108,6 +108,7 @@ namespace Source {
     static AspellConfig* spellcheck_config;
     AspellCanHaveError *spellcheck_possible_err;
     AspellSpeller *spellcheck_checker;
+    bool is_word_iter(const Gtk::TextIter& iter);
     std::pair<Gtk::TextIter, Gtk::TextIter> spellcheck_get_word(Gtk::TextIter iter);
     void spellcheck_word(const Gtk::TextIter& start, const Gtk::TextIter& end);
     std::vector<std::string> spellcheck_get_suggestions(const Gtk::TextIter& start, const Gtk::TextIter& end);

--- a/src/source.h
+++ b/src/source.h
@@ -169,6 +169,7 @@ namespace Source {
     
     Glib::Dispatcher parse_done;
     Glib::Dispatcher parse_start;
+    Glib::Dispatcher parse_fail;
     std::map<std::string, std::string> parse_thread_buffer_map;
     std::mutex parse_thread_buffer_map_mutex;
     std::atomic<bool> parse_thread_go;

--- a/src/source.h
+++ b/src/source.h
@@ -95,8 +95,8 @@ namespace Source {
     std::string get_line_before(Glib::RefPtr<Gtk::TextBuffer::Mark> mark);
     std::string get_line_before();
     
-    bool find_start_of_sentence(Gtk::TextIter iter, Gtk::TextIter &found_iter);
-    bool find_open_symbol(Gtk::TextIter iter, const Gtk::TextIter &until_iter, Gtk::TextIter &found_iter);
+    bool find_start_of_closed_expression(Gtk::TextIter iter, Gtk::TextIter &found_iter);
+    bool find_open_expression_symbol(Gtk::TextIter iter, const Gtk::TextIter &until_iter, Gtk::TextIter &found_iter);
     bool find_right_bracket_forward(Gtk::TextIter iter, Gtk::TextIter &found_iter);
     
     bool on_key_press_event(GdkEventKey* key);
@@ -109,6 +109,8 @@ namespace Source {
     std::regex tabs_regex;
     
     bool spellcheck_all=false;
+    std::unique_ptr<SelectionDialog> spellcheck_suggestions_dialog;
+    bool spellcheck_suggestions_dialog_shown=false;
   private:
     GtkSourceSearchContext *search_context;
     GtkSourceSearchSettings *search_settings;
@@ -121,8 +123,6 @@ namespace Source {
     std::pair<Gtk::TextIter, Gtk::TextIter> spellcheck_get_word(Gtk::TextIter iter);
     void spellcheck_word(const Gtk::TextIter& start, const Gtk::TextIter& end);
     std::vector<std::string> spellcheck_get_suggestions(const Gtk::TextIter& start, const Gtk::TextIter& end);
-    std::unique_ptr<SelectionDialog> spellcheck_suggestions_dialog;
-    bool spellcheck_suggestions_dialog_shown=false;
     sigc::connection delayed_spellcheck_suggestions_connection;
     bool last_keyval_is_backspace=false;
   };

--- a/src/source.h
+++ b/src/source.h
@@ -124,6 +124,7 @@ namespace Source {
   class ClangViewParse : public View {
   public:
     ClangViewParse(const boost::filesystem::path &file_path, const boost::filesystem::path& project_path);
+    ~ClangViewParse();
     boost::filesystem::path project_path;
     void start_reparse();
     bool start_reparse_needed=false;
@@ -187,6 +188,7 @@ namespace Source {
   class ClangViewRefactor : public ClangViewAutocomplete {
   public:
     ClangViewRefactor(const boost::filesystem::path &file_path, const boost::filesystem::path& project_path);
+    ~ClangViewRefactor();
   private:
     Glib::RefPtr<Gtk::TextTag> similar_tokens_tag;
     std::string last_similar_tokens_tagged;

--- a/src/source.h
+++ b/src/source.h
@@ -87,10 +87,16 @@ namespace Source {
     
     void set_status(const std::string &status);
     
-    std::string get_line(size_t line_number);
-    std::string get_line_before_insert();
+    std::string get_line(const Gtk::TextIter &iter);
+    std::string get_line(Glib::RefPtr<Gtk::TextBuffer::Mark> mark);
+    std::string get_line(int line_nr);
+    std::string get_line();
+    std::string get_line_before(const Gtk::TextIter &iter);
+    std::string get_line_before(Glib::RefPtr<Gtk::TextBuffer::Mark> mark);
+    std::string get_line_before();
     
     bool find_start_of_sentence(Gtk::TextIter iter, Gtk::TextIter &found_iter);
+    bool find_open_symbol(Gtk::TextIter iter, const Gtk::TextIter &until_iter, Gtk::TextIter &found_iter);
     bool find_right_bracket_forward(Gtk::TextIter iter, Gtk::TextIter &found_iter);
     
     bool on_key_press_event(GdkEventKey* key);

--- a/src/sourcefile.cc
+++ b/src/sourcefile.cc
@@ -15,7 +15,7 @@ std::string juci::filesystem::read(const std::string &path) {
   return ss.str();
 }
 
-bool juci::filesystem::read(const std::string &path, Glib::RefPtr<Gtk::TextBuffer> text_buffer) {
+int juci::filesystem::read(const std::string &path, Glib::RefPtr<Gtk::TextBuffer> text_buffer) {
   std::ifstream input(path, std::ofstream::binary);
   
   if(input) {
@@ -24,11 +24,14 @@ bool juci::filesystem::read(const std::string &path, Glib::RefPtr<Gtk::TextBuffe
     ss << input.rdbuf();
     Glib::ustring ustr=std::move(ss.str());
     
+    bool valid=true;
     Glib::ustring::iterator iter;
     while(!ustr.validate(iter)) {
       auto next_char_iter=iter;
       next_char_iter++;
       ustr.replace(iter, next_char_iter, "?");
+      if(valid)
+        valid=false;
     }
     
     text_buffer->insert_at_cursor(ustr);
@@ -54,9 +57,12 @@ bool juci::filesystem::read(const std::string &path, Glib::RefPtr<Gtk::TextBuffe
       text_buffer->insert_at_cursor(ustr); //What if insert happens in the middle of an UTF-8 char???
     }*/
     input.close();
-    return true;
+    if(valid)
+      return 1;
+    else
+      return -1;
   }
-  return false;
+  return 0;
 }
 
 //Only use on small files

--- a/src/sourcefile.cc
+++ b/src/sourcefile.cc
@@ -25,16 +25,20 @@ int juci::filesystem::read(const std::string &path, Glib::RefPtr<Gtk::TextBuffer
     Glib::ustring ustr=std::move(ss.str());
     
     bool valid=true;
-    Glib::ustring::iterator iter;
+    //This was way too slow...
+    /*Glib::ustring::iterator iter;
     while(!ustr.validate(iter)) {
       auto next_char_iter=iter;
       next_char_iter++;
       ustr.replace(iter, next_char_iter, "?");
       if(valid)
         valid=false;
-    }
+    }*/
     
-    text_buffer->insert_at_cursor(ustr);
+    if(ustr.validate())
+      text_buffer->insert_at_cursor(ustr);
+    else
+      valid=false;
     
     //TODO: maybe correct this, emphasis on maybe:
     /*std::vector<char> buffer(buffer_size);

--- a/src/sourcefile.cc
+++ b/src/sourcefile.cc
@@ -70,9 +70,7 @@ bool juci::filesystem::write(const std::string &path, Glib::RefPtr<Gtk::TextBuff
     bool end_reached=false;
     while(!end_reached) {
       for(size_t c=0;c<buffer_size;c++) {
-        if(end_iter)
-          end_iter++;
-        else {
+        if(!end_iter.forward_char()) {
           end_reached=true;
           break;
         }

--- a/src/sourcefile.h
+++ b/src/sourcefile.h
@@ -10,8 +10,8 @@ namespace juci {
   public:
     static std::string read(const std::string &path);
     static std::string read(const boost::filesystem::path &path) { return read(path.string()); }
-    static bool read(const std::string &path, Glib::RefPtr<Gtk::TextBuffer> text_buffer);
-    static bool read(const boost::filesystem::path &path, Glib::RefPtr<Gtk::TextBuffer> text_buffer) { return read(path.string(), text_buffer); }
+    static int read(const std::string &path, Glib::RefPtr<Gtk::TextBuffer> text_buffer);
+    static int read(const boost::filesystem::path &path, Glib::RefPtr<Gtk::TextBuffer> text_buffer) { return read(path.string(), text_buffer); }
 
     static std::vector<std::string> read_lines(const std::string &path);
     static std::vector<std::string> read_lines(const boost::filesystem::path &path) { return read_lines(path.string()); };

--- a/src/terminal.cc
+++ b/src/terminal.cc
@@ -280,7 +280,7 @@ void Terminal::kill_async_executes(bool force) {
 }
 
 int Terminal::print(const std::string &message, bool bold){
-  INFO("Terminal: PrintMessage");
+  DEBUG("start");
   if(bold)
     get_buffer()->insert_with_tag(get_buffer()->end(), message, bold_tag);
   else
@@ -293,15 +293,16 @@ int Terminal::print(const std::string &message, bool bold){
     get_buffer()->delete_mark(mark);
   }
   
+  DEBUG("end");
   return get_buffer()->end().get_line();
 }
 
 void Terminal::print(int line_nr, const std::string &message){
-  INFO("Terminal: PrintMessage at line " << line_nr);
+  DEBUG("start");
   auto iter=get_buffer()->get_iter_at_line(line_nr);
-  while(!iter.ends_line())
-    iter++;
+  while(!iter.ends_line() && iter.forward_char()) {}
   get_buffer()->insert(iter, message);
+  DEBUG("end");
 }
 
 std::shared_ptr<Terminal::InProgress> Terminal::print_in_progress(std::string start_msg) {

--- a/src/terminal.cc
+++ b/src/terminal.cc
@@ -283,14 +283,22 @@ void Terminal::kill_async_executes(bool force) {
 }
 
 int Terminal::print(const std::string &message, bool bold){
+  Glib::ustring umessage=message;
+  Glib::ustring::iterator iter;
+  while(!umessage.validate(iter)) {
+    auto next_char_iter=iter;
+    next_char_iter++;
+    umessage.replace(iter, next_char_iter, "?");
+  }
+  
   if(bold)
-    get_buffer()->insert_with_tag(get_buffer()->end(), message, bold_tag);
+    get_buffer()->insert_with_tag(get_buffer()->end(), umessage, bold_tag);
   else
-    get_buffer()->insert(get_buffer()->end(), message);
+    get_buffer()->insert(get_buffer()->end(), umessage);
     
-  auto iter=get_buffer()->end();
-  if(iter.backward_char()) {
-    auto mark=get_buffer()->create_mark(iter);
+  auto end_iter=get_buffer()->end();
+  if(end_iter.backward_char()) {
+    auto mark=get_buffer()->create_mark(end_iter);
     scroll_to(mark, 0.0, 1.0, 1.0);
     get_buffer()->delete_mark(mark);
   }
@@ -299,9 +307,17 @@ int Terminal::print(const std::string &message, bool bold){
 }
 
 void Terminal::print(int line_nr, const std::string &message){
-  auto iter=get_buffer()->get_iter_at_line(line_nr);
-  while(!iter.ends_line() && iter.forward_char()) {}
-  get_buffer()->insert(iter, message);
+  Glib::ustring umessage=message;
+  Glib::ustring::iterator iter;
+  while(!umessage.validate(iter)) {
+    auto next_char_iter=iter;
+    next_char_iter++;
+    umessage.replace(iter, next_char_iter, "?");
+  }
+  
+  auto end_line_iter=get_buffer()->get_iter_at_line(line_nr);
+  while(!end_line_iter.ends_line() && end_line_iter.forward_char()) {}
+  get_buffer()->insert(end_line_iter, umessage);
 }
 
 std::shared_ptr<Terminal::InProgress> Terminal::print_in_progress(std::string start_msg) {

--- a/src/terminal.cc
+++ b/src/terminal.cc
@@ -154,6 +154,7 @@ Terminal::Terminal() {
 }
 
 int Terminal::execute(const std::string &command, const boost::filesystem::path &path) {
+  DEBUG("start");
   int stdin_fd, stdout_fd, stderr_fd;
   auto pid=popen3(command, path.string(), &stdin_fd, &stdout_fd, &stderr_fd);
   
@@ -176,7 +177,6 @@ int Terminal::execute(const std::string &command, const boost::filesystem::path 
     std::thread stdout_thread([this, stdout_fd](){
       char buffer[1024];
       ssize_t n;
-      INFO("read");
       while ((n=read(stdout_fd, buffer, 1024)) > 0) {
         std::string message;
         for(ssize_t c=0;c<n;c++)
@@ -192,12 +192,14 @@ int Terminal::execute(const std::string &command, const boost::filesystem::path 
     close(stdout_fd);
     close(stderr_fd);
     
+    DEBUG("end");
     return exit_code;
   }
 }
 
 void Terminal::async_execute(const std::string &command, const boost::filesystem::path &path, std::function<void(int exit_code)> callback) {
   std::thread async_execute_thread([this, command, path, callback](){
+    DEBUG("start");
     int stdin_fd, stdout_fd, stderr_fd;
     async_executes_mutex.lock();
     stdin_buffer.clear();
@@ -225,7 +227,6 @@ void Terminal::async_execute(const std::string &command, const boost::filesystem
       std::thread stdout_thread([this, stdout_fd](){
         char buffer[1024];
         ssize_t n;
-        INFO("read");
         while ((n=read(stdout_fd, buffer, 1024)) > 0) {
           std::string message;
           for(ssize_t c=0;c<n;c++)
@@ -252,6 +253,8 @@ void Terminal::async_execute(const std::string &command, const boost::filesystem
       
       if(callback)
         callback(exit_code);
+
+      DEBUG("end");
     }
   });
   async_execute_thread.detach();
@@ -280,7 +283,6 @@ void Terminal::kill_async_executes(bool force) {
 }
 
 int Terminal::print(const std::string &message, bool bold){
-  DEBUG("start");
   if(bold)
     get_buffer()->insert_with_tag(get_buffer()->end(), message, bold_tag);
   else
@@ -293,16 +295,13 @@ int Terminal::print(const std::string &message, bool bold){
     get_buffer()->delete_mark(mark);
   }
   
-  DEBUG("end");
   return get_buffer()->end().get_line();
 }
 
 void Terminal::print(int line_nr, const std::string &message){
-  DEBUG("start");
   auto iter=get_buffer()->get_iter_at_line(line_nr);
   while(!iter.ends_line() && iter.forward_char()) {}
   get_buffer()->insert(iter, message);
-  DEBUG("end");
 }
 
 std::shared_ptr<Terminal::InProgress> Terminal::print_in_progress(std::string start_msg) {

--- a/src/tooltips.cc
+++ b/src/tooltips.cc
@@ -35,7 +35,7 @@ void Tooltip::update() {
   auto end_iter=end_mark->get_iter();
   text_view.get_iter_location(iter, activation_rectangle);
   if(iter.get_offset()<end_iter.get_offset()) {
-    while(iter!=end_iter && iter.forward_char()) {
+    while(iter.forward_char() && iter!=end_iter) {
       Gdk::Rectangle rectangle;
       text_view.get_iter_location(iter, rectangle);
       activation_rectangle.join(rectangle);

--- a/src/tooltips.cc
+++ b/src/tooltips.cc
@@ -1,6 +1,9 @@
 #include "tooltips.h"
 #include "singletons.h"
 
+#include <iostream>
+using namespace std;
+
 namespace sigc {
   template <typename Functor>
   struct functor_trait<Functor, false> {
@@ -28,12 +31,10 @@ void Tooltip::update() {
   auto end_iter=end_mark->get_iter();
   text_view.get_iter_location(iter, activation_rectangle);
   if(iter.get_offset()<end_iter.get_offset()) {
-    iter++;
-    while(iter!=end_iter) {
+    while(iter!=end_iter && iter.forward_char()) {
       Gdk::Rectangle rectangle;
       text_view.get_iter_location(iter, rectangle);
       activation_rectangle.join(rectangle);
-      iter++;
     }
   }
   int location_window_x, location_window_y;
@@ -107,28 +108,28 @@ void Tooltip::wrap_lines(Glib::RefPtr<Gtk::TextBuffer> text_buffer) {
         last_space=iter;
       if(*iter=='\n') {
         end=true;
-        iter++;
+        iter.forward_char();
         break;
       }
-      iter++;
+      iter.forward_char();
     }
     if(!end) {
       while(!last_space && iter) { //If no space (word longer than 80)
-        iter++;
+        iter.forward_char();
         if(iter && *iter==' ')
           last_space=iter;
       }
       if(iter && last_space) {
         auto mark=text_buffer->create_mark(last_space);
-        auto iter_mark=text_buffer->create_mark(iter);
-        auto last_space_p=last_space++;
-        text_buffer->erase(last_space, last_space_p);
+        auto last_space_p=last_space;
+        last_space.forward_char();
+        text_buffer->erase(last_space_p, last_space);
         text_buffer->insert(mark->get_iter(), "\n");
         
-        iter=iter_mark->get_iter();
+        iter=mark->get_iter();
+        iter.forward_char();
 
         text_buffer->delete_mark(mark);
-        text_buffer->delete_mark(iter_mark);
       }
     }
   }

--- a/src/tooltips.cc
+++ b/src/tooltips.cc
@@ -93,7 +93,6 @@ void Tooltip::adjust(bool disregard_drawn) {
 }
 
 void Tooltip::wrap_lines(Glib::RefPtr<Gtk::TextBuffer> text_buffer) {
-  INFO("Tooltip::wrap_lines");
   auto iter=text_buffer->begin();
   
   while(iter) {

--- a/src/window.cc
+++ b/src/window.cc
@@ -29,7 +29,7 @@ void Window::generate_keybindings() {
 }
 
 Window::Window() : box(Gtk::ORIENTATION_VERTICAL), notebook(directories), compiling(false) {
-  INFO("Create Window");
+  DEBUG("start");
   set_title("juCi++");
   set_default_size(600, 400);
   set_events(Gdk::POINTER_MOTION_MASK|Gdk::FOCUS_CHANGE_MASK|Gdk::SCROLL_MASK);
@@ -80,7 +80,6 @@ Window::Window() : box(Gtk::ORIENTATION_VERTICAL), notebook(directories), compil
   });
 
   notebook.signal_switch_page().connect([this](Gtk::Widget* page, guint page_num) {
-    DEBUG("start");
     if(notebook.get_current_page()!=-1) {
       if(search_entry_shown && entry_box.labels.size()>0) {
         notebook.get_current_view()->update_search_occurrences=[this](int number){
@@ -109,7 +108,6 @@ Window::Window() : box(Gtk::ORIENTATION_VERTICAL), notebook(directories), compil
       
       Singleton::status()->set_text(notebook.get_current_view()->status);
     }
-    DEBUG("end");
   });
   notebook.signal_page_removed().connect([this](Gtk::Widget* page, guint page_num) {
     entry_box.hide();
@@ -130,11 +128,10 @@ Window::Window() : box(Gtk::ORIENTATION_VERTICAL), notebook(directories), compil
   about.set_comments("This is an open source IDE with high-end features to make your programming experience juicy");
   about.set_license_type(Gtk::License::LICENSE_MIT_X11);
   about.set_transient_for(*this);
-  INFO("Window created");
+  DEBUG("end");
 } // Window constructor
 
 void Window::create_menu() {
-  INFO("Adding actions to menu");
   menu.action_group->add(Gtk::Action::create("FileQuit", "Quit juCi++"), Gtk::AccelKey(menu.key_map["quit"]), [this]() {
     hide();
   });
@@ -187,7 +184,6 @@ void Window::create_menu() {
     search_and_replace_entry();
   });
   menu.action_group->add(Gtk::Action::create("EditUndo", "Undo"), Gtk::AccelKey(menu.key_map["edit_undo"]), [this]() {
-    INFO("On undo");
     if(notebook.get_current_page()!=-1) {
       auto undo_manager = notebook.get_current_view()->get_source_buffer()->get_undo_manager();
       if (undo_manager->can_undo()) {
@@ -195,10 +191,8 @@ void Window::create_menu() {
         notebook.get_current_view()->scroll_to(notebook.get_current_view()->get_buffer()->get_insert());
       }
     }
-    INFO("Done undo");
   });
   menu.action_group->add(Gtk::Action::create("EditRedo", "Redo"), Gtk::AccelKey(menu.key_map["edit_redo"]), [this]() {
-    INFO("On Redo");
     if(notebook.get_current_page()!=-1) {
       auto undo_manager = notebook.get_current_view()->get_source_buffer()->get_undo_manager();
       if(undo_manager->can_redo()) {
@@ -206,7 +200,6 @@ void Window::create_menu() {
         notebook.get_current_view()->scroll_to(notebook.get_current_view()->get_buffer()->get_insert());
       }
     }
-    INFO("Done Redo");
   });
 
   menu.action_group->add(Gtk::Action::create("SourceGotoLine", "Go to Line"), Gtk::AccelKey(menu.key_map["source_goto_line"]), [this]() {
@@ -336,7 +329,6 @@ void Window::create_menu() {
   });
   add_accel_group(menu.ui_manager->get_accel_group()); 
   menu.build();
-  INFO("Menu build")
 }
 
 bool Window::on_key_press_event(GdkEventKey *event) {
@@ -530,7 +522,6 @@ void Window::open_file_dialog() {
 void Window::save_file_dialog() {
   if(notebook.get_current_page()==-1)
     return;
-  INFO("Save file dialog");
   Gtk::FileChooserDialog dialog(*this, "Please choose a file", Gtk::FILE_CHOOSER_ACTION_SAVE);
   gtk_file_chooser_set_filename((GtkFileChooser*)dialog.gobj(), notebook.get_current_view()->file_path.string().c_str());
   dialog.set_position(Gtk::WindowPosition::WIN_POS_CENTER_ALWAYS);

--- a/src/window.cc
+++ b/src/window.cc
@@ -325,6 +325,8 @@ void Window::create_menu() {
   });
   menu.action_group->add(Gtk::Action::create("WindowCloseTab", "Close Tab"), Gtk::AccelKey(menu.key_map["close_tab"]), [this]() {
     notebook.close_current_page();
+    if(notebook.get_current_page()!=-1)
+      Singleton::status()->set_text(notebook.get_current_view()->status);
   });
   menu.action_group->add(Gtk::Action::create("HelpAbout", "About"), [this] () {
     about.show();

--- a/src/window.cc
+++ b/src/window.cc
@@ -80,6 +80,7 @@ Window::Window() : box(Gtk::ORIENTATION_VERTICAL), notebook(directories), compil
   });
 
   notebook.signal_switch_page().connect([this](Gtk::Widget* page, guint page_num) {
+    DEBUG("start");
     if(notebook.get_current_page()!=-1) {
       if(search_entry_shown && entry_box.labels.size()>0) {
         notebook.get_current_view()->update_search_occurrences=[this](int number){
@@ -108,6 +109,7 @@ Window::Window() : box(Gtk::ORIENTATION_VERTICAL), notebook(directories), compil
       
       Singleton::status()->set_text(notebook.get_current_view()->status);
     }
+    DEBUG("end");
   });
   notebook.signal_page_removed().connect([this](Gtk::Widget* page, guint page_num) {
     entry_box.hide();

--- a/src/window.cc
+++ b/src/window.cc
@@ -214,7 +214,8 @@ void Window::create_menu() {
     if(notebook.get_current_page()!=-1) {
       while(gtk_events_pending())
         gtk_main_iteration();
-      notebook.get_current_view()->scroll_to(notebook.get_current_view()->get_buffer()->get_insert(), 0.0, 1.0, 0.5);
+      if(notebook.get_current_page()!=-1)
+        notebook.get_current_view()->scroll_to(notebook.get_current_view()->get_buffer()->get_insert(), 0.0, 1.0, 0.5);
     }
   });
   menu.action_group->add(Gtk::Action::create("SourceGotoDeclaration", "Go to Declaration"), Gtk::AccelKey(menu.key_map["source_goto_declaration"]), [this]() {
@@ -226,7 +227,8 @@ void Window::create_menu() {
           notebook.get_current_view()->get_buffer()->place_cursor(notebook.get_current_view()->get_buffer()->get_iter_at_line_index(location.second.line-1, location.second.index-1));
           while(gtk_events_pending())
             gtk_main_iteration();
-          notebook.get_current_view()->scroll_to(notebook.get_current_view()->get_buffer()->get_insert(), 0.0, 1.0, 0.5);
+          if(notebook.get_current_page()!=-1)
+            notebook.get_current_view()->scroll_to(notebook.get_current_view()->get_buffer()->get_insert(), 0.0, 1.0, 0.5);
         }
       }
     }

--- a/src/window.cc
+++ b/src/window.cc
@@ -327,6 +327,8 @@ void Window::create_menu() {
     notebook.close_current_page();
     if(notebook.get_current_page()!=-1)
       Singleton::status()->set_text(notebook.get_current_view()->status);
+    else
+      Singleton::status()->set_text("");
   });
   menu.action_group->add(Gtk::Action::create("HelpAbout", "About"), [this] () {
     about.show();

--- a/src/window.cc
+++ b/src/window.cc
@@ -104,9 +104,9 @@ Window::Window() : box(Gtk::ORIENTATION_VERTICAL), notebook(directories), compil
       directories.select(notebook.get_current_view()->file_path);
       
       if(auto source_view=dynamic_cast<Source::ClangView*>(notebook.get_current_view())) {
-        if(source_view->start_reparse_needed) {
+        if(source_view->reparse_needed) {
           source_view->start_reparse();
-          source_view->start_reparse_needed=false;
+          source_view->reparse_needed=false;
         }
       }
       
@@ -688,10 +688,11 @@ void Window::rename_token_entry() {
         entry_box.entries.emplace_back(*token_name, [this, token_name, token](const std::string& content){
           if(notebook.get_current_page()!=-1 && content!=*token_name) {
             for(int c=0;c<notebook.size();c++) {
-              if(notebook.get_view(c)->rename_similar_tokens) {
-                auto number=notebook.get_view(c)->rename_similar_tokens(*token, content);
+              auto view=notebook.get_view(c);
+              if(view->rename_similar_tokens) {
+                auto number=view->rename_similar_tokens(*token, content);
                 if(number>0) {
-                  Singleton::terminal()->print("Replaced "+boost::lexical_cast<std::string>(number)+" occurrences in file "+notebook.get_view(c)->file_path.string()+"\n");
+                  Singleton::terminal()->print("Replaced "+boost::lexical_cast<std::string>(number)+" occurrences in file "+view->file_path.string()+"\n");
                   notebook.save(c);
                 }
               }

--- a/src/window.cc
+++ b/src/window.cc
@@ -650,7 +650,8 @@ void Window::goto_line_entry() {
             buffer->place_cursor(buffer->get_iter_at_line(line));
             while(gtk_events_pending())
               gtk_main_iteration();
-            notebook.get_current_view()->scroll_to(buffer->get_insert(), 0.0, 1.0, 0.5);
+            if(notebook.get_current_page()!=-1)
+              notebook.get_current_view()->scroll_to(buffer->get_insert(), 0.0, 1.0, 0.5);
           }
         }
         catch(const std::exception &e) {}  


### PR DESCRIPTION
Tested on Ubuntu 14, debian stable/testing, OS X and MSYS2. 

The clang indentation should now work flawlessly (hopefully) in every case, even in multi-line expressions. 

Would be nice if we could merge this soon, after you have tested it of course. If there are issues, I will try fix it Today or Tomorrow, but I will not commit more features before it's merged:)