### PR TITLE
Dialogs now has equal behaviour

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,14 @@ find_package(LibClang REQUIRED)
 
 #find_package(Boost 1.55 COMPONENTS python thread log system filesystem REQUIRED)
 
-find_package(Boost 1.55 COMPONENTS thread log system filesystem locale REQUIRED)
+set(BOOST_DEP thread log system filesystem)
+
+if(MSYS)
+  list(APPEND BOOST_DEP locale)
+endif()
+
+
+find_package(Boost 1.55 COMPONENTS ${BOOST_DEP} REQUIRED)
 
 pkg_check_modules(GTKMM gtkmm-3.0 REQUIRED) # The name GTKMM is set here for the variables abouve
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,7 +107,6 @@ include_directories(
   ${LIBCLANG_INCLUDE_DIRS}
   ${ASPELL_INCLUDE_DIR}
   ../libclangmm/src
-  "/usr/x86_64-w64-mingw32/include"
 )
 
 link_directories(
@@ -116,7 +115,6 @@ link_directories(
   ${Boost_LIBRARY_DIRS}
 #    ${PYTHON_INCLUDE_DIRS}
   ${LIBCLANG_LIBRARY_DIRS}
-  "/usr/x86_64-w64-mingw32/lib"
 )
 
 #  set_target_properties(${module}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,8 @@ find_package(LibClang REQUIRED)
 #find_package(PythonLibs 2.7)
 
 #find_package(Boost 1.55 COMPONENTS python thread log system filesystem REQUIRED)
-find_package(Boost 1.55 COMPONENTS thread log system filesystem REQUIRED)
+
+find_package(Boost 1.55 COMPONENTS thread log system filesystem locale REQUIRED)
 
 pkg_check_modules(GTKMM gtkmm-3.0 REQUIRED) # The name GTKMM is set here for the variables abouve
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,7 @@ include_directories(
   ${LIBCLANG_INCLUDE_DIRS}
   ${ASPELL_INCLUDE_DIR}
   ../libclangmm/src
+  "/usr/x86_64-w64-mingw32/include"
 )
 
 link_directories(
@@ -114,6 +115,7 @@ link_directories(
   ${Boost_LIBRARY_DIRS}
 #    ${PYTHON_INCLUDE_DIRS}
   ${LIBCLANG_LIBRARY_DIRS}
+  "/usr/x86_64-w64-mingw32/lib"
 )
 
 #  set_target_properties(${module}

--- a/src/dialogs.h
+++ b/src/dialogs.h
@@ -38,8 +38,14 @@ private:
 class CommonDialog {
 public:
   CommonDialog(CLSID type);
+  /** available options are listed https://msdn.microsoft.com/en-gb/library/windows/desktop/dn457282(v=vs.85).aspx */
   void add_option(unsigned option);
   void set_title(const std::string &title);
+  /** Sets the extensions the browser can find */
+  void set_file_extensions(const std::vector<std::string> file_extensions);
+  /** Sets the directory to start browsing */
+  void set_default_folder(const std::string &directory_path);
+  /** Returns the selected item's path as a string */
   std::string show();
 
 private:
@@ -49,18 +55,12 @@ private:
 
 class OpenDialog : public CommonDialog {
 public:
-  OpenDialog(const std::string &title, unsigned option) : CommonDialog(CLSID_FileOpenDialog) {
-    set_title(title);
-    add_option(option);
-  }
+  OpenDialog(const std::string &title, unsigned option) : CommonDialog(CLSID_FileOpenDialog);
 };
-
 class SaveDialog : public CommonDialog {
 public:
-  SaveDialog(const std::string &title, unsigned option) : CommonDialog(CLSID_FileSaveDialog) {
-    set_title(title);
-    add_option(option);
-  }
+  SaveDialog(const std::string &title, unsigned option) : CommonDialog(CLSID_FileSaveDialog);
 };
+
 #endif  // __WIN32
 #endif  // JUCI_DIALOG_H_

--- a/src/dialogs.h
+++ b/src/dialogs.h
@@ -36,11 +36,9 @@ public:
   /** Returns the selected item's path as a string */
   std::string show();
 
-private:
+protected:
   IFileDialog * dialog;
   DWORD options;
-  const std::vector<std::wstring> text_files = {L"Text files", L"*.txt;*.c"};
-  const std::vector<std::wstring> all_files = {L"", L""};
 };
 
 class OpenDialog : public CommonDialog {
@@ -50,6 +48,8 @@ public:
 class SaveDialog : public CommonDialog {
 public:
   SaveDialog(std::string &&title, unsigned option);
+private:
+  std::vector<COMDLG_FILTERSPEC> extensions;
 };
 
 #endif  // __WIN32

--- a/src/dialogs.h
+++ b/src/dialogs.h
@@ -21,6 +21,7 @@ class Dialog {
 #include <memory>
 #include <sstream>
 #include <codecvt>
+#include <vector>
 
 class WinString {
 public:
@@ -29,10 +30,11 @@ public:
   ~WinString() { CoTaskMemFree(static_cast<void*>(str)); }
   std::string operator()();
   wchar_t** operator&() { return &str; }
+  static std::wstring s2ws(const std::string& str);
+  static std::string ws2s(const std::wstring& wstr);
+
 private:
   wchar_t* str;
-  std::wstring s2ws(const std::string& str);
-  std::string ws2s(const std::wstring& wstr);
 };
 
 class CommonDialog {
@@ -42,7 +44,7 @@ public:
   void add_option(unsigned option);
   void set_title(const std::string &title);
   /** Sets the extensions the browser can find */
-  void set_file_extensions(const std::vector<std::string> file_extensions);
+  void set_file_extensions(const std::vector<std::string> &file_extensions);
   /** Sets the directory to start browsing */
   void set_default_folder(const std::string &directory_path);
   /** Returns the selected item's path as a string */
@@ -55,11 +57,11 @@ private:
 
 class OpenDialog : public CommonDialog {
 public:
-  OpenDialog(const std::string &title, unsigned option) : CommonDialog(CLSID_FileOpenDialog);
+  OpenDialog(const std::string &title, unsigned option);
 };
 class SaveDialog : public CommonDialog {
 public:
-  SaveDialog(const std::string &title, unsigned option) : CommonDialog(CLSID_FileSaveDialog);
+  SaveDialog(const std::string &title, unsigned option);
 };
 
 #endif  // __WIN32

--- a/src/dialogs.h
+++ b/src/dialogs.h
@@ -23,28 +23,14 @@ class Dialog {
 #include <codecvt>
 #include <vector>
 
-class WinString {
-public:
-  WinString() : str(nullptr) { }
-  WinString(const std::string &string);
-  ~WinString() { CoTaskMemFree(static_cast<void*>(str)); }
-  std::string operator()();
-  wchar_t** operator&() { return &str; }
-  static std::wstring s2ws(const std::string& str);
-  static std::string ws2s(const std::wstring& wstr);
-
-private:
-  wchar_t* str;
-};
-
 class CommonDialog {
 public:
   CommonDialog(CLSID type);
   /** available options are listed https://msdn.microsoft.com/en-gb/library/windows/desktop/dn457282(v=vs.85).aspx */
   void add_option(unsigned option);
-  void set_title(const std::string &title);
+  void set_title(std::string &&title);
   /** Sets the extensions the browser can find */
-  void set_file_extensions(const std::vector<std::string> &file_extensions);
+  void set_default_file_extension(std::string &&file_extension);
   /** Sets the directory to start browsing */
   void set_default_folder(const std::string &directory_path);
   /** Returns the selected item's path as a string */
@@ -53,15 +39,17 @@ public:
 private:
   IFileDialog * dialog;
   DWORD options;
+  const std::vector<std::wstring> text_files = {L"Text files", L"*.txt;*.c"};
+  const std::vector<std::wstring> all_files = {L"", L""};
 };
 
 class OpenDialog : public CommonDialog {
 public:
-  OpenDialog(const std::string &title, unsigned option);
+  OpenDialog(std::string &&title, unsigned option);
 };
 class SaveDialog : public CommonDialog {
 public:
-  SaveDialog(const std::string &title, unsigned option);
+  SaveDialog(std::string &&title, unsigned option);
 };
 
 #endif  // __WIN32

--- a/src/dialogs.h
+++ b/src/dialogs.h
@@ -17,10 +17,6 @@ class Dialog {
 
 #include <windows.h>
 #include <shobjidl.h>
-
-#include <memory>
-#include <sstream>
-#include <codecvt>
 #include <vector>
 
 class CommonDialog {

--- a/src/dialogs_win.cc
+++ b/src/dialogs_win.cc
@@ -12,84 +12,53 @@ HRESULT __hr__;
 }                                                
 #endif  // CHECK
 
-
-// { WINSTRING
-WinString::WinString(const std::string &string) {
-  std::wstringstream ss;
-    ss << s2ws(string);
-    ss >> str;
-}
-
-std::string WinString::operator()() {
-  std::string res;
-  if (str != nullptr) {
-    std::wstring ss(str);
-    res = ws2s(ss);
-  }
-  return res;
-}
-
-std::wstring WinString::s2ws(const std::string& str) {
-  return boost::locale::conv::utf_to_utf<wchar_t>(str);
-}
-
-std::string WinString::ws2s(const std::wstring& wstr) {
-  return boost::locale::conv::utf_to_utf<char>(wstr);
-}
-
-// WINSTRING }
-
 // { COMMON_DIALOG
 CommonDialog::CommonDialog(CLSID type) : dialog(nullptr) {
     check(CoCreateInstance(type, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&dialog)), "Failed to create instance");
     check(dialog->GetOptions(&options), "Failed to get options from instance");
 }
-
-void CommonDialog::set_title(const std::string &title) {
-  check(dialog->SetTitle(), "Failed to set dialog title");
+void CommonDialog::set_title(std::string &&title) {
+  auto ptr = boost::locale::conv::utf_to_utf<wchar_t>(title).data();
+  check(dialog->SetTitle(ptr), "Failed to set dialog title");
 }
-
 void CommonDialog::add_option(unsigned option) {
   check(dialog->SetOptions(options | option), "Failed to set options");
 }
-
-void CommonDialog::set_file_extensions(const std::vector<std::string> &file_extensions) {
-  return;
+void CommonDialog::set_default_file_extension(std::string &&file_extensions) {
+  
 }
-
 void CommonDialog::set_default_folder(const std::string &directory_path) {
-  std::cout << directory_path << std::endl;
   IShellItem * folder = nullptr;
-  auto dir = WinString::s2ws(directory_path);
-  std::wcout << dir << std::endl;
-  check(SHCreateItemFromParsingName(dir.data(), nullptr, IID_PPV_ARGS(&folder)), "Failed to create string");
+  auto ptr = boost::locale::conv::utf_to_utf<wchar_t>(directory_path).data();
+  check(SHCreateItemFromParsingName(ptr, nullptr, IID_PPV_ARGS(&folder)), "Failed to create string");
   check(dialog->SetDefaultFolder(folder), "Failed to set default folder");
   folder->Release();
 }
-
 std::string CommonDialog::show() {
   try {
     check(dialog->Show(nullptr), "Failed to show dialog");
     IShellItem *result = nullptr;
     check(dialog->GetResult(&result), "Failed to get result from dialog");
-    WinString str;
+    LPWSTR str = nullptr; 
     check(result->GetDisplayName(SIGDN_FILESYSPATH, &str), "Failed to get display name from dialog");
     result->Release();
-    return str();
+    auto res = boost::locale::conv::utf_to_utf<char>(str);
+    CoTaskMemFree(str);
+    return res;
   } catch (std::exception e) {
     return "";
   }
 }
 
-OpenDialog::OpenDialog(const std::string &title, unsigned option) : CommonDialog(CLSID_FileOpenDialog) {
-  set_title(title);
+OpenDialog::OpenDialog(std::string &&title, unsigned option) : CommonDialog(CLSID_FileOpenDialog) {
+  set_title(std::move(title));
   add_option(option);
   auto dirs = Singleton::directories()->current_path;
   set_default_folder(dirs.empty() ? boost::filesystem::current_path().string() : dirs.string());
 }
 
-SaveDialog::SaveDialog(const std::string &title, unsigned option) : CommonDialog(CLSID_FileSaveDialog) {
-  set_title(title);
+SaveDialog::SaveDialog(std::string &&title, unsigned option) : CommonDialog(CLSID_FileSaveDialog) {
+  set_title(std::move(title));
   add_option(option);
   auto dirs = Singleton::directories()->current_path;
   set_default_folder(dirs.empty() ? boost::filesystem::current_path().string() : dirs.string());

--- a/src/dialogs_win.cc
+++ b/src/dialogs_win.cc
@@ -60,6 +60,19 @@ void CommonDialog::add_option(unsigned option) {
   check(dialog->SetOptions(options | option), "Failed to set options");
 }
 
+void CommonDialog::set_file_extensions(const std::vector<std::string> &file_extensions) {
+  return;
+}
+
+void CommonDialog::set_default_folder(const std::string &directory_path) {
+  IShellItem * folder = nullptr;
+  WinString str;
+  &str = (str.s2ws(directory_path)).data();
+  check(SHCreateItemFromParsingName(&str, NULL, IID_PPV_ARGS(&folder)), "Failed to create string");
+  check(dialog->SetDefaultFolder(folder), "Failed to set default folder");
+  folder->Release();
+}
+
 std::string CommonDialog::show() {
   try {
     check(dialog->Show(nullptr), "Failed to show dialog");
@@ -73,7 +86,22 @@ std::string CommonDialog::show() {
     return "";
   }
 }
-// COMMON_DIALOG }}
+
+OpenDialog::OpenDialog(const std::string &title, unsigned option) : CommonDialog(CLSID_FileOpenDialog); {
+  set_title(title);
+  add_option(option);
+  auto dirs = Singleton::directories()->current_path;
+  set_default_folder(dirs.empty() ? boost::filesystem::current_path() : dirs);
+}
+
+SaveDialog::SaveDialog(const std::string &title, unsigned option) : CommonDialog(CLSID_FileSaveDialog) {
+  set_title(title);
+  add_option(option);
+  auto dirs = Singleton::directories()->current_path;
+  set_default_folder(dirs.empty() ? boost::filesystem::current_path() : dirs);
+}
+
+// DIALOGS }}
 std::string Dialog::select_folder() {
   return (OpenDialog("Select folder", FOS_PICKFOLDERS)).show();
 }

--- a/src/dialogs_win.cc
+++ b/src/dialogs_win.cc
@@ -24,8 +24,9 @@ void CommonDialog::set_title(std::string &&title) {
 void CommonDialog::add_option(unsigned option) {
   check(dialog->SetOptions(options | option), "Failed to set options");
 }
-void CommonDialog::set_default_file_extension(std::string &&file_extensions) {
-  
+void CommonDialog::set_default_file_extension(std::string &&file_extension) {
+  auto ptr = boost::locale::conv::utf_to_utf<wchar_t>(file_extension).data();
+  check(dialog->SetDefaultExtension(ptr), "Failed to set file extension");
 }
 void CommonDialog::set_default_folder(const std::string &directory_path) {
   IShellItem * folder = nullptr;
@@ -62,6 +63,12 @@ SaveDialog::SaveDialog(std::string &&title, unsigned option) : CommonDialog(CLSI
   add_option(option);
   auto dirs = Singleton::directories()->current_path;
   set_default_folder(dirs.empty() ? boost::filesystem::current_path().string() : dirs.string());
+  extensions.emplace_back(COMDLG_FILTERSPEC{L"Default", L"*.h;*.cpp"});
+  extensions.emplace_back(COMDLG_FILTERSPEC{L"GoogleStyle", L"*.cc;*.h"});
+  extensions.emplace_back(COMDLG_FILTERSPEC{L"BoostStyle", L"*.hpp;*.cpp"});
+  extensions.emplace_back(COMDLG_FILTERSPEC{L"Other", L"*.cxx;*.c"});
+  check(dialog->SetFileTypes(extensions.size(), extensions.data()), "Failed to set extensions");
+  set_default_file_extension("Default");
 }
 
 // DIALOGS }}


### PR DESCRIPTION
* Introduce boost.locale dependency in Msys, no need to update dependencies since it is automatically installed when installing boost
* Fix crashes due to special characters
* Correct start directory is now selected, slightly different behavior than gtk due to windows conventions
* Default file extension is selected as .cpp 
* Less copies due to move semantics