### PR TITLE
Adding arch install instructions and removal of gtkmm3 dependencies

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -68,7 +68,8 @@ make install
 ##Arch
 Install dependencies:
 ```sh
-pacman -S git cmake make clang gtksourceviewmm3 boost aspell aspell-en
+#as root
+pacman -S git cmake make clang gtksourceviewmm boost aspell aspell-en
 ```
 
 Get juCi++ source, compile and install

--- a/docs/install.md
+++ b/docs/install.md
@@ -65,6 +65,22 @@ make
 make install
 ```
 
+##Arch
+Install dependencies:
+```sh
+pacman -S git cmake make clang gtkmm3 gtksourceviewmm3 boost aspell aspell-en
+```
+
+Get juCi++ source, compile and install
+```sh
+git clone --recursive https://github.com/cppit/jucipp
+cd jucipp
+cmake .
+make
+# as root
+make install
+```
+
 <!--
 ## Windows with Cygwin (https://www.cygwin.com/)
 **Make sure the PATH environment variable does not include paths to non-Cygwin cmake, make and g++.**

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,7 +3,7 @@
 ## Debian/Ubuntu 15
 Install dependencies:
 ```sh
-sudo apt-get install git cmake make g++ libclang-dev pkg-config libboost-system-dev libboost-thread-dev libboost-filesystem-dev libboost-log-dev libgtkmm-3.0-dev libgtksourceviewmm-3.0-dev aspell-en libaspell-dev
+sudo apt-get install git cmake make g++ libclang-dev pkg-config libboost-system-dev libboost-thread-dev libboost-filesystem-dev libboost-log-dev libgtksourceviewmm-3.0-dev aspell-en libaspell-dev
 sudo apt-get install clang-format-3.6 || sudo apt-get install clang-format-3.5
 ```
 
@@ -23,7 +23,7 @@ sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get update
 sudo apt-get install g++-4.9
 sudo apt-get remove g++-4.8
-sudo apt-get install git cmake make g++ libclang-3.6-dev clang-format-3.6 pkg-config libboost-system1.55-dev libboost-thread1.55-dev libboost-filesystem1.55-dev libboost-log1.55-dev libgtkmm-3.0-dev libgtksourceviewmm-3.0-dev aspell-en libaspell-dev
+sudo apt-get install git cmake make g++ libclang-3.6-dev clang-format-3.6 pkg-config libboost-system1.55-dev libboost-thread1.55-dev libboost-filesystem1.55-dev libboost-log1.55-dev libgtksourceviewmm-3.0-dev aspell-en libaspell-dev
 ```
 
 Get juCi++ source, compile and install:
@@ -38,7 +38,7 @@ sudo make install
 ## OS X with Homebrew (http://brew.sh/)
 Install dependencies (installing llvm may take some time):
 ```sh
-brew install cmake --with-clang llvm pkg-config boost gtkmm3 homebrew/x11/gtksourceviewmm3 aspell clang-format
+brew install cmake --with-clang llvm pkg-config boost homebrew/x11/gtksourceviewmm3 aspell clang-format
 ```
 
 Get juCi++ source, compile and install:
@@ -53,7 +53,7 @@ make install
 ##Windows with MSYS2 (https://msys2.github.io/)
 Install dependencies (replace `x86_64` with `i686` for 32-bit MSYS2 installs):
 ```sh
-pacman -S git mingw-w64-x86_64-cmake make mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang mingw-w64-x86_64-gtkmm3 mingw-w64-x86_64-gtksourceviewmm3 mingw-w64-x86_64-boost mingw-w64-x86_64-aspell mingw-w64-x86_64-aspell-en
+pacman -S git mingw-w64-x86_64-cmake make mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang mingw-w64-x86_64-gtksourceviewmm3 mingw-w64-x86_64-boost mingw-w64-x86_64-aspell mingw-w64-x86_64-aspell-en
 ```
 
 Get juCi++ source, compile and install (replace `mingw64` with `mingw32` for 32-bit MSYS2 installs):
@@ -68,7 +68,7 @@ make install
 ##Arch
 Install dependencies:
 ```sh
-pacman -S git cmake make clang gtkmm3 gtksourceviewmm3 boost aspell aspell-en
+pacman -S git cmake make clang gtksourceviewmm3 boost aspell aspell-en
 ```
 
 Get juCi++ source, compile and install


### PR DESCRIPTION
* Add arch install instuctions
* Remove gtkmm3 as dependency (it gets automatically installed by gtksourceviewmm)

Before merge
- [x] Test instructions in arch @zalox
- [x] Test whether removal of gtkmm3 breaks install on other platforms
- [x] Add gtkmm3 to dependencies of gtksourceviewmm in msys2