### PR TITLE
Correct next/previous tab keys for Linux

### DIFF
--- a/src/files.h
+++ b/src/files.h
@@ -98,8 +98,8 @@ const std::string configjson =
 "        \"kill_last_running\": \"<primary>Escape\",\n"
 "        \"force_kill_last_running\": \"<primary><shift>Escape\",\n"
 #ifdef __linux
-"        \"next_tab\": \"<primary>Page_Down\",\n"
-"        \"previous_tab\": \"<primary>Page_Up\",\n"
+"        \"next_tab\": \"<primary>Tab\",\n"
+"        \"previous_tab\": \"<primary><shift>Tab\",\n"
 #else
 "        \"next_tab\": \"<primary><alt>Right\",\n"
 "        \"previous_tab\": \"<primary><alt>Left\",\n"

--- a/src/files.h
+++ b/src/files.h
@@ -97,8 +97,13 @@ const std::string configjson =
 "        \"run_command\": \"<alt>Return\",\n"
 "        \"kill_last_running\": \"<primary>Escape\",\n"
 "        \"force_kill_last_running\": \"<primary><shift>Escape\",\n"
+#ifdef __linux
+"        \"next_tab\": \"<primary>Page_Down\",\n"
+"        \"previous_tab\": \"<primary>Page_Up\",\n"
+#else
 "        \"next_tab\": \"<primary><alt>Right\",\n"
 "        \"previous_tab\": \"<primary><alt>Left\",\n"
+#endif
 "        \"close_tab\": \"<primary>w\"\n"
 "    },\n"
 "    \"project\": {\n"


### PR DESCRIPTION
If this works better for your Arch Linux we can merge this before v1.0.0 release.

Tested on:
- [x] Debian testing
- [x] Debian stable
- [ ] Linux Mint
- [ ] Ubuntu 14
- [x] Ubuntu 15
- [x] Arch Linux
