### PR TITLE
Install desktop file in a portable, build-dir-independent way

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,7 @@ project (${project_name})
 
 add_subdirectory("src")
 
-find_program(XDG_DESKTOP_MENU_EXECUTABLE xdg-desktop-menu)
-if(XDG_DESKTOP_MENU_EXECUTABLE)
-  file(MAKE_DIRECTORY "/usr/share/desktop-directories") #Workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=730621
-  install(CODE "execute_process(COMMAND ${XDG_DESKTOP_MENU_EXECUTABLE} install --novendor share/juci.desktop)")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|OpenBSD|NetBSD")
+    install(FILES "${CMAKE_SOURCE_DIR}/share/juci.desktop"
+        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications")
 endif()


### PR DESCRIPTION
Install location matches http://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html

Previous process of installation would attempt to create a directory before the install process, preventing usage in something like the Arch User Repository.
This also removes the need to workaround any bugs present with desktop file installation tools.