### PR TITLE
Better support for Allman bracket style (break before bracket)

### DIFF
--- a/src/selectiondialog.cc
+++ b/src/selectiondialog.cc
@@ -31,15 +31,15 @@ ListViewText::ListViewText(bool use_markup) : Gtk::TreeView(), use_markup(use_ma
   set_activate_on_single_click(true);
   set_hover_selection(false);
   set_rules_hint(true);
-  
-  signal_hide().connect([this]() {
-    list_store->clear();
-  });
 }
 
 void ListViewText::append(const std::string& value) {
   auto new_row=list_store->append();
   new_row->set_value(column_record.text, value);
+}
+
+void ListViewText::clear() {
+  list_store->clear();
 }
 
 SelectionDialogBase::SelectionDialogBase(Gtk::TextView& text_view, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, bool show_search_entry, bool use_markup): text_view(text_view), 
@@ -107,6 +107,7 @@ void SelectionDialogBase::hide() {
     tooltips->hide();
   if(on_hide)
     on_hide();
+  list_view_text.clear();
   shown=false;
 }
 

--- a/src/selectiondialog.cc
+++ b/src/selectiondialog.cc
@@ -31,16 +31,15 @@ ListViewText::ListViewText(bool use_markup) : Gtk::TreeView(), use_markup(use_ma
   set_activate_on_single_click(true);
   set_hover_selection(false);
   set_rules_hint(true);
+  
+  signal_hide().connect([this]() {
+    list_store->clear();
+  });
 }
 
 void ListViewText::append(const std::string& value) {
   auto new_row=list_store->append();
   new_row->set_value(column_record.text, value);
-}
-
-void ListViewText::hide() {
-  Gtk::TreeView::hide();
-  list_store->clear();
 }
 
 SelectionDialogBase::SelectionDialogBase(Gtk::TextView& text_view, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, bool show_search_entry, bool use_markup): text_view(text_view), 
@@ -101,10 +100,12 @@ void SelectionDialogBase::show() {
 }
 
 void SelectionDialogBase::hide() {
+  if(!shown)
+    return;
   window->hide();
   if(tooltips)
     tooltips->hide();
-  if(on_hide && shown)
+  if(on_hide)
     on_hide();
   shown=false;
 }

--- a/src/selectiondialog.h
+++ b/src/selectiondialog.h
@@ -18,7 +18,6 @@ public:
   bool use_markup;
   ListViewText(bool use_markup);
   void append(const std::string& value);
-  void hide();
 private:
   Glib::RefPtr<Gtk::ListStore> list_store;
   ColumnRecord column_record;

--- a/src/selectiondialog.h
+++ b/src/selectiondialog.h
@@ -18,6 +18,7 @@ public:
   bool use_markup;
   ListViewText(bool use_markup);
   void append(const std::string& value);
+  void clear();
 private:
   Glib::RefPtr<Gtk::ListStore> list_store;
   ColumnRecord column_record;

--- a/src/source.cc
+++ b/src/source.cc
@@ -217,7 +217,7 @@ Source::View::View(const boost::filesystem::path &file_path, const boost::filesy
       return;
     
     if(mark->get_name()=="insert") {
-      if(spellcheck_suggestions_dialog && spellcheck_suggestions_dialog->shown)
+      if(spellcheck_suggestions_dialog)
         spellcheck_suggestions_dialog->hide();
       delayed_spellcheck_suggestions_connection.disconnect();
       delayed_spellcheck_suggestions_connection=Glib::signal_timeout().connect([this]() {
@@ -429,11 +429,11 @@ void Source::View::set_tooltip_and_dialog_events() {
       type_tooltips.hide();
       diagnostic_tooltips.hide();
       
-      if(spellcheck_suggestions_dialog && spellcheck_suggestions_dialog->shown)
+      if(spellcheck_suggestions_dialog)
         spellcheck_suggestions_dialog->hide();
-      if(autocomplete_dialog && autocomplete_dialog->shown)
+      if(autocomplete_dialog)
         autocomplete_dialog->hide();
-      if(selection_dialog && selection_dialog->shown)
+      if(selection_dialog)
         selection_dialog->hide();
       
       set_info(info);
@@ -445,11 +445,11 @@ void Source::View::set_tooltip_and_dialog_events() {
     type_tooltips.hide();
     diagnostic_tooltips.hide();
     delayed_spellcheck_suggestions_connection.disconnect();
-    if(spellcheck_suggestions_dialog && spellcheck_suggestions_dialog->shown)
+    if(spellcheck_suggestions_dialog)
       spellcheck_suggestions_dialog->hide();
-    if(autocomplete_dialog && autocomplete_dialog->shown)
+    if(autocomplete_dialog)
       autocomplete_dialog->hide();
-    if(selection_dialog && selection_dialog->shown)
+    if(selection_dialog)
       selection_dialog->hide();
     return false;
   });
@@ -459,9 +459,9 @@ void Source::View::set_tooltip_and_dialog_events() {
     type_tooltips.hide();
     diagnostic_tooltips.hide();
     delayed_spellcheck_suggestions_connection.disconnect();
-    if(spellcheck_suggestions_dialog && spellcheck_suggestions_dialog->shown)
+    if(spellcheck_suggestions_dialog)
       spellcheck_suggestions_dialog->hide();
-    if(autocomplete_dialog && autocomplete_dialog->shown)
+    if(autocomplete_dialog)
       autocomplete_dialog->hide();
     return false;
   });

--- a/src/source_clang.cc
+++ b/src/source_clang.cc
@@ -605,6 +605,35 @@ bool Source::ClangViewParse::on_key_press_event(GdkEventKey* key) {
     get_source_buffer()->end_user_action();
     return true;
   }
+  //Indent left when writing { on a new line after for instance if(...)\n...
+  else if(key->keyval==GDK_KEY_braceleft) {
+    auto iter=get_buffer()->get_insert()->get_iter();
+    auto tabs_end_iter=get_tabs_end_iter();
+    auto tabs=get_line_before(tabs_end_iter);
+    size_t line_nr=get_source_buffer()->get_insert()->get_iter().get_line();
+    if(line_nr>0 && tabs.size()>=tab_size && iter==tabs_end_iter) {
+      std::string previous_line=get_line(line_nr-1);
+      boost::smatch sm;
+      if(!boost::regex_match(previous_line, sm, bracket_regex)) {
+        auto start_iter=iter;
+        start_iter.backward_chars(tab_size);
+        if(boost::regex_match(previous_line, sm, no_bracket_statement_regex)) {
+          get_buffer()->erase(start_iter, iter);
+          get_buffer()->insert_at_cursor("{");
+          scroll_to(get_source_buffer()->get_insert());
+          get_buffer()->end_user_action();
+          return true;
+        }
+        else if(boost::regex_match(previous_line, sm, no_bracket_no_para_statement_regex)) {
+          get_buffer()->erase(start_iter, iter);
+          get_buffer()->insert_at_cursor("{");
+          scroll_to(get_source_buffer()->get_insert());
+          get_buffer()->end_user_action();
+          return true;
+        }
+      }
+    }
+  }
   
   get_source_buffer()->end_user_action();
   return Source::View::on_key_press_event(key);

--- a/src/source_clang.cc
+++ b/src/source_clang.cc
@@ -99,8 +99,8 @@ void Source::ClangViewParse::configure() {
   }
   
   bracket_regex=boost::regex("^([ \\t]*).*\\{ *$");
-  no_bracket_statement_regex=boost::regex("^([ \\t]*)(if|for|else if|catch|while) *\\(.*[^;}] *$");
-  no_bracket_no_para_statement_regex=boost::regex("^([ \\t]*)(else|try|do) *$");
+  no_bracket_statement_regex=boost::regex("^([ \\t]*)(if|for|else if|while) *\\(.*[^;}] *$");
+  no_bracket_no_para_statement_regex=boost::regex("^([ \\t]*)(else) *$");
 }
 
 void Source::ClangViewParse::parse_initialize() {
@@ -610,24 +610,18 @@ bool Source::ClangViewParse::on_key_press_event(GdkEventKey* key) {
     auto iter=get_buffer()->get_insert()->get_iter();
     auto tabs_end_iter=get_tabs_end_iter();
     auto tabs=get_line_before(tabs_end_iter);
-    size_t line_nr=get_source_buffer()->get_insert()->get_iter().get_line();
+    size_t line_nr=iter.get_line();
     if(line_nr>0 && tabs.size()>=tab_size && iter==tabs_end_iter) {
       std::string previous_line=get_line(line_nr-1);
       boost::smatch sm;
       if(!boost::regex_match(previous_line, sm, bracket_regex)) {
         auto start_iter=iter;
         start_iter.backward_chars(tab_size);
-        if(boost::regex_match(previous_line, sm, no_bracket_statement_regex)) {
+        if(boost::regex_match(previous_line, sm, no_bracket_statement_regex) ||
+           boost::regex_match(previous_line, sm, no_bracket_no_para_statement_regex)) {
           get_buffer()->erase(start_iter, iter);
           get_buffer()->insert_at_cursor("{");
-          scroll_to(get_source_buffer()->get_insert());
-          get_buffer()->end_user_action();
-          return true;
-        }
-        else if(boost::regex_match(previous_line, sm, no_bracket_no_para_statement_regex)) {
-          get_buffer()->erase(start_iter, iter);
-          get_buffer()->insert_at_cursor("{");
-          scroll_to(get_source_buffer()->get_insert());
+          scroll_to(get_buffer()->get_insert());
           get_buffer()->end_user_action();
           return true;
         }


### PR DESCRIPTION
Now indent left after '{', so that you do not need to use shift-tab when writing:
```c++
if(true)
{
  //do something
}
```