### PR TITLE
Removed redundant keybinding

### DIFF
--- a/src/files.h
+++ b/src/files.h
@@ -95,7 +95,6 @@ const std::string configjson =
 "        \"project_set_run_arguments\": \"\",\n"
 "        \"compile_and_run\": \"<primary>Return\",\n"
 "        \"compile\": \"<primary><shift>Return\",\n"
-"        \"compile_and_run\": \"<primary>Return\",\n"
 "        \"run_command\": \"<alt>Return\",\n"
 "        \"kill_last_running\": \"<primary>Escape\",\n"
 "        \"force_kill_last_running\": \"<primary><shift>Escape\",\n"


### PR DESCRIPTION
Keybinding for compile_and_run was defined twice