### PR TITLE
Project cleanup - easier to support compile/run/debug for other languages

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -86,7 +86,7 @@ make install
 ```
 
 ##Windows with MSYS2 (https://msys2.github.io/)
-**MSYS2 does not yet support lldb, but you can still compile juCi++ without debug support. Also for the time being, MSYS2 must be installed in the default MSYS2 folder (C:\msys64 or C:\msys32).**
+**MSYS2 does not yet support lldb, but you can still compile juCi++ without debug support.**
 
 Note that juCi++ must be run in a MinGW Shell (for instance MinGW-w64 Win64 Shell). 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,8 @@ set(source_files juci.h
     dialogs.cc
     project.h
     project.cc
+    dispatcher.h
+    dispatcher.cc
     
     ../libclangmm/src/CodeCompleteResults.cc
     ../libclangmm/src/CompilationDatabase.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,7 +107,7 @@ set(source_files juci.h
     ../tiny-process-library/process.cpp)
 
 if(LIBLLDB_FOUND)
-  list(APPEND source_files debug.h debug.cc)
+  list(APPEND source_files debug_clang.h debug_clang.cc)
 endif()
 
 if(MSYS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,13 +10,13 @@ if(APPLE)
   set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig")
 endif()
 
-if(UNIX) #Checking if compiling on Ubuntu that has a buggy menu system
+if(UNIX) #Checking if compiling on Ubuntu that for instance has a buggy menu system
   find_program(LSB_RELEASE_BIN lsb_release)
   if(LSB_RELEASE_BIN)
     execute_process(COMMAND ${LSB_RELEASE_BIN} -is
       OUTPUT_VARIABLE DISTRIBUTION OUTPUT_STRIP_TRAILING_WHITESPACE)
     if((DISTRIBUTION STREQUAL Ubuntu) OR (DISTRIBUTION STREQUAL LinuxMint))
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DJUCI_UBUNTU_BUGGED_MENU")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DJUCI_UBUNTU")
     endif()
   endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,8 @@ set(source_files juci.h
     cmake.h
     cmake.cc
     dialogs.cc
+    project.h
+    project.cc
     
     ../libclangmm/src/CodeCompleteResults.cc
     ../libclangmm/src/CompilationDatabase.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,10 +21,6 @@ if(UNIX) #Checking if compiling on Ubuntu that has a buggy menu system
   endif()
 endif()
 
-if(MSYS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMSYS_PROCESS_USE_SH -DJUCI_CMAKE_INSTALL_PREFIX=\\\"${CMAKE_INSTALL_PREFIX}\\\"")
-endif()
-
 INCLUDE(FindPkgConfig)
 
 find_package(LibClang REQUIRED)

--- a/src/cmake.cc
+++ b/src/cmake.cc
@@ -36,7 +36,7 @@ CMake::CMake(const boost::filesystem::path &path) {
 }
 
 boost::filesystem::path CMake::get_default_build_path(const boost::filesystem::path &project_path) {
-  boost::filesystem::path default_build_path=Config::get().terminal.default_build_path;
+  boost::filesystem::path default_build_path=Config::get().project.default_build_path;
   
   const std::string path_variable_project_directory_name="<project_directory_name>";
   size_t pos=0;
@@ -56,7 +56,7 @@ boost::filesystem::path CMake::get_default_build_path(const boost::filesystem::p
 }
 
 boost::filesystem::path CMake::get_debug_build_path(const boost::filesystem::path &project_path) {
-  boost::filesystem::path debug_build_path=Config::get().terminal.debug_build_path;
+  boost::filesystem::path debug_build_path=Config::get().project.debug_build_path;
   
   const std::string path_variable_project_directory_name="<project_directory_name>";
   size_t pos=0;
@@ -72,7 +72,7 @@ boost::filesystem::path CMake::get_debug_build_path(const boost::filesystem::pat
   const std::string path_variable_default_build_path="<default_build_path>";
   pos=0;
   debug_build_path_string=debug_build_path.string();
-  auto default_build_path=Config::get().terminal.default_build_path;
+  auto default_build_path=Config::get().project.default_build_path;
   while((pos=debug_build_path_string.find(path_variable_default_build_path, pos))!=std::string::npos) {
     debug_build_path_string.replace(pos, path_variable_default_build_path.size(), default_build_path);
     pos+=default_build_path.size();
@@ -112,7 +112,7 @@ bool CMake::create_default_build(const boost::filesystem::path &project_path, bo
   
   auto compile_commands_path=default_build_path/"compile_commands.json";
   Dialog::Message message("Creating/updating default build");
-  auto exit_status=Terminal::get().process(Config::get().terminal.cmake_command+" "+
+  auto exit_status=Terminal::get().process(Config::get().project.cmake_command+" "+
                                            filesystem::escape_argument(project_path)+" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON", default_build_path);
   message.hide();
   if(exit_status==EXIT_SUCCESS) {
@@ -162,7 +162,7 @@ bool CMake::create_debug_build(const boost::filesystem::path &project_path) {
   
   std::unique_ptr<Dialog::Message> message;
   message=std::unique_ptr<Dialog::Message>(new Dialog::Message("Creating/updating debug build"));
-  auto exit_status=Terminal::get().process(Config::get().terminal.cmake_command+" "+
+  auto exit_status=Terminal::get().process(Config::get().project.cmake_command+" "+
                                            filesystem::escape_argument(project_path)+" -DCMAKE_BUILD_TYPE=Debug", debug_build_path);
   if(message)
     message->hide();

--- a/src/config.cc
+++ b/src/config.cc
@@ -84,15 +84,15 @@ void Config::retrieve_config() {
   window.theme_variant=cfg.get<std::string>("gtk_theme.variant");
   window.version = cfg.get<std::string>("version");
   window.default_size = {cfg.get<int>("default_window_size.width"), cfg.get<int>("default_window_size.height")};
-  window.save_on_compile_or_run=cfg.get<bool>("project.save_on_compile_or_run");
   
-  terminal.default_build_path=cfg.get<std::string>("project.default_build_path");
-  terminal.debug_build_path=cfg.get<std::string>("project.debug_build_path");
-  terminal.make_command=cfg.get<std::string>("project.make_command");
-  terminal.cmake_command=cfg.get<std::string>("project.cmake_command");
+  project.save_on_compile_or_run=cfg.get<bool>("project.save_on_compile_or_run");
+  project.default_build_path=cfg.get<std::string>("project.default_build_path");
+  project.debug_build_path=cfg.get<std::string>("project.debug_build_path");
+  project.make_command=cfg.get<std::string>("project.make_command");
+  project.cmake_command=cfg.get<std::string>("project.cmake_command");
+  
   terminal.history_size=cfg.get<int>("terminal_history_size");
-  
-  terminal.clang_format_command=cfg.get<std::string>("project.clang_format_command", "clang-format");
+  terminal.clang_format_command="clang-format";
 #ifdef __linux
   if(terminal.clang_format_command=="clang-format" &&
      !boost::filesystem::exists("/usr/bin/clang-format") && !boost::filesystem::exists("/usr/local/bin/clang-format")) {

--- a/src/config.cc
+++ b/src/config.cc
@@ -5,6 +5,7 @@
 #include <iostream>
 #include "filesystem.h"
 #include "terminal.h"
+#include <algorithm>
 
 Config::Config() {
   std::vector<std::string> environment_variables = {"JUCI_HOME", "HOME", "AppData"};
@@ -25,6 +26,13 @@ Config::Config() {
     searched_envs+="]";
     throw std::runtime_error("One of these environment variables needs to point to a writable directory to save configuration: " + searched_envs);
   }
+  
+#ifdef _WIN32
+    terminal.msys2_mingw_path=boost::filesystem::path(std::getenv("WD")).parent_path().parent_path().parent_path();
+    std::string msystem=std::getenv("MSYSTEM");
+    std::transform(msystem.begin(), msystem.end(), msystem.begin(), ::tolower);
+    terminal.msys2_mingw_path/=msystem;
+#endif
 }
 
 void Config::load() {

--- a/src/config.cc
+++ b/src/config.cc
@@ -28,10 +28,14 @@ Config::Config() {
   }
   
 #ifdef _WIN32
-    terminal.msys2_mingw_path=boost::filesystem::path(std::getenv("WD")).parent_path().parent_path().parent_path();
-    std::string msystem=std::getenv("MSYSTEM");
-    std::transform(msystem.begin(), msystem.end(), msystem.begin(), ::tolower);
-    terminal.msys2_mingw_path/=msystem;
+    auto env_WD=std::getenv("WD");
+    auto env_MSYSTEM=std::getenv("MSYSTEM");
+    if(env_WD!=NULL && env_MSYSTEM!=NULL) {
+      terminal.msys2_mingw_path=boost::filesystem::path(env_WD).parent_path().parent_path().parent_path();
+      std::string msystem=env_MSYSTEM;
+      std::transform(msystem.begin(), msystem.end(), msystem.begin(), ::tolower);
+      terminal.msys2_mingw_path/=msystem;
+    }
 #endif
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -20,17 +20,21 @@ public:
     std::string theme_variant;
     std::string version;
     std::pair<int, int> default_size;
-    bool save_on_compile_or_run;
   };
   
   class Terminal {
+  public:
+    std::string clang_format_command;
+    int history_size;
+  };
+  
+  class Project {
   public:
     std::string default_build_path;
     std::string debug_build_path;
     std::string cmake_command;
     std::string make_command;
-    std::string clang_format_command;
-    int history_size;
+    bool save_on_compile_or_run;
   };
   
   class Source {
@@ -74,6 +78,7 @@ public:
   Menu menu;
   Window window;
   Terminal terminal;
+  Project project;
   Source source;
   
   const boost::filesystem::path& juci_home_path() const { return home; }

--- a/src/config.h
+++ b/src/config.h
@@ -26,6 +26,10 @@ public:
   public:
     std::string clang_format_command;
     int history_size;
+    
+#ifdef _WIN32
+    boost::filesystem::path msys2_mingw_path;
+#endif
   };
   
   class Project {

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -36,7 +36,7 @@ Debug::Debug(): state(lldb::StateType::eStateInvalid), buffer_size(131072) {
 }
 
 void Debug::start(const std::string &command, const boost::filesystem::path &path,
-                  std::shared_ptr<std::vector<std::pair<boost::filesystem::path, int> > > breakpoints,
+                  const std::vector<std::pair<boost::filesystem::path, int> > &breakpoints,
                   std::function<void(int exit_status)> callback,
                   std::function<void(const std::string &status)> status_callback,
                   std::function<void(const boost::filesystem::path &file_path, int line_nr, int line_index)> stop_callback) {
@@ -88,14 +88,12 @@ void Debug::start(const std::string &command, const boost::filesystem::path &pat
   }
   
   //Set breakpoints
-  if(breakpoints) {
-    for(auto &breakpoint: *breakpoints) {
-      if(!(target.BreakpointCreateByLocation(breakpoint.first.string().c_str(), breakpoint.second)).IsValid()) {
-        Terminal::get().async_print("Error (debug): Could not create breakpoint at: "+breakpoint.first.string()+":"+std::to_string(breakpoint.second)+'\n', true);
-        if(callback)
-          callback(-1);
-        return;
-      }
+  for(auto &breakpoint: breakpoints) {
+    if(!(target.BreakpointCreateByLocation(breakpoint.first.string().c_str(), breakpoint.second)).IsValid()) {
+      Terminal::get().async_print("Error (debug): Could not create breakpoint at: "+breakpoint.first.string()+":"+std::to_string(breakpoint.second)+'\n', true);
+      if(callback)
+        callback(-1);
+      return;
     }
   }
   

--- a/src/debug.h
+++ b/src/debug.h
@@ -39,7 +39,7 @@ public:
   }
   
   void start(const std::string &command, const boost::filesystem::path &path="",
-             std::shared_ptr<std::vector<std::pair<boost::filesystem::path, int> > > breakpoints=nullptr,
+             const std::vector<std::pair<boost::filesystem::path, int> > &breakpoints={},
              std::function<void(int exit_status)> callback=nullptr,
              std::function<void(const std::string &status)> status_callback=nullptr,
              std::function<void(const boost::filesystem::path &file_path, int line_nr, int line_index)> stop_callback=nullptr);

--- a/src/debug_clang.h
+++ b/src/debug_clang.h
@@ -1,5 +1,5 @@
-#ifndef JUCI_DEBUG_H_
-#define JUCI_DEBUG_H_
+#ifndef JUCI_DEBUG_CLANG_H_
+#define JUCI_DEBUG_CLANG_H_
 
 #include <boost/filesystem.hpp>
 #include <unordered_map>
@@ -9,7 +9,7 @@
 #include <thread>
 #include <mutex>
 
-class Debug {
+class DebugClang {
 public:
   class Frame {
   public:
@@ -31,10 +31,10 @@ public:
     int line_index;
   };
 private:
-  Debug();
+  DebugClang();
 public:
-  static Debug &get() {
-    static Debug singleton;
+  static DebugClang &get() {
+    static DebugClang singleton;
     return singleton;
   }
   

--- a/src/debug_clang.h
+++ b/src/debug_clang.h
@@ -9,75 +9,77 @@
 #include <thread>
 #include <mutex>
 
-class DebugClang {
-public:
-  class Frame {
+namespace Debug {
+  class Clang {
   public:
-    uint32_t index;
-    std::string module_filename;
-    std::string file_path;
-    std::string function_name;
-    int line_nr;
-    int line_index;
-  };
-  class Variable {
+    class Frame {
+    public:
+      uint32_t index;
+      std::string module_filename;
+      std::string file_path;
+      std::string function_name;
+      int line_nr;
+      int line_index;
+    };
+    class Variable {
+    public:
+      uint32_t thread_index_id;
+      uint32_t frame_index;
+      std::string name;
+      std::string value;
+      boost::filesystem::path file_path;
+      int line_nr;
+      int line_index;
+    };
+  private:
+    Clang();
   public:
-    uint32_t thread_index_id;
-    uint32_t frame_index;
-    std::string name;
-    std::string value;
-    boost::filesystem::path file_path;
-    int line_nr;
-    int line_index;
-  };
-private:
-  DebugClang();
-public:
-  static DebugClang &get() {
-    static DebugClang singleton;
-    return singleton;
-  }
-  
-  void start(const std::string &command, const boost::filesystem::path &path="",
-             const std::vector<std::pair<boost::filesystem::path, int> > &breakpoints={},
-             std::function<void(int exit_status)> callback=nullptr,
-             std::function<void(const std::string &status)> status_callback=nullptr,
-             std::function<void(const boost::filesystem::path &file_path, int line_nr, int line_index)> stop_callback=nullptr);
-  void continue_debug(); //can't use continue as function name
-  void stop();
-  void kill();
-  void step_over();
-  void step_into();
-  void step_out();
-  std::pair<std::string, std::string> run_command(const std::string &command);
-  std::vector<Frame> get_backtrace();
-  std::vector<Variable> get_variables();
-  void select_frame(uint32_t frame_index, uint32_t thread_index_id=0);
-  
-  void delete_debug(); //can't use delete as function name
-  
-  std::string get_value(const std::string &variable, const boost::filesystem::path &file_path, unsigned int line_nr, unsigned int line_index);
-  std::string get_return_value(const boost::filesystem::path &file_path, unsigned int line_nr, unsigned int line_index);
-  
-  bool is_invalid();
-  bool is_stopped();
-  bool is_running();
-  
-  void add_breakpoint(const boost::filesystem::path &file_path, int line_nr);
-  void remove_breakpoint(const boost::filesystem::path &file_path, int line_nr, int line_count);
-  
-  void write(const std::string &buffer);
+    static Clang &get() {
+      static Clang singleton;
+      return singleton;
+    }
     
-private:
-  std::unique_ptr<lldb::SBDebugger> debugger;
-  std::unique_ptr<lldb::SBListener> listener;
-  std::unique_ptr<lldb::SBProcess> process;
-  std::thread debug_thread;
-  
-  lldb::StateType state;
-  std::mutex event_mutex;
-  
-  size_t buffer_size;
-};
+    void start(const std::string &command, const boost::filesystem::path &path="",
+               const std::vector<std::pair<boost::filesystem::path, int> > &breakpoints={},
+               std::function<void(int exit_status)> callback=nullptr,
+               std::function<void(const std::string &status)> status_callback=nullptr,
+               std::function<void(const boost::filesystem::path &file_path, int line_nr, int line_index)> stop_callback=nullptr);
+    void continue_debug(); //can't use continue as function name
+    void stop();
+    void kill();
+    void step_over();
+    void step_into();
+    void step_out();
+    std::pair<std::string, std::string> run_command(const std::string &command);
+    std::vector<Frame> get_backtrace();
+    std::vector<Variable> get_variables();
+    void select_frame(uint32_t frame_index, uint32_t thread_index_id=0);
+    
+    void delete_debug(); //can't use delete as function name
+    
+    std::string get_value(const std::string &variable, const boost::filesystem::path &file_path, unsigned int line_nr, unsigned int line_index);
+    std::string get_return_value(const boost::filesystem::path &file_path, unsigned int line_nr, unsigned int line_index);
+    
+    bool is_invalid();
+    bool is_stopped();
+    bool is_running();
+    
+    void add_breakpoint(const boost::filesystem::path &file_path, int line_nr);
+    void remove_breakpoint(const boost::filesystem::path &file_path, int line_nr, int line_count);
+    
+    void write(const std::string &buffer);
+      
+  private:
+    std::unique_ptr<lldb::SBDebugger> debugger;
+    std::unique_ptr<lldb::SBListener> listener;
+    std::unique_ptr<lldb::SBProcess> process;
+    std::thread debug_thread;
+    
+    lldb::StateType state;
+    std::mutex event_mutex;
+    
+    size_t buffer_size;
+  };
+}
 
 #endif

--- a/src/dialogs.cc
+++ b/src/dialogs.cc
@@ -1,5 +1,6 @@
 #include "dialogs.h"
 #include "window.h"
+#include "notebook.h"
 #include <cmath>
 
 namespace sigc {
@@ -34,7 +35,7 @@ std::string Dialog::gtk_dialog(const std::string &title,
   
   dialog.set_transient_for(Window::get());
   
-  auto current_path=Window::get().notebook.get_current_folder();
+  auto current_path=Notebook::get().get_current_folder();
   boost::system::error_code ec;
   if(current_path.empty())
     current_path=boost::filesystem::current_path(ec);

--- a/src/directories.cc
+++ b/src/directories.cc
@@ -96,7 +96,7 @@ Directories::Directories() : Gtk::TreeView(), stop_update_thread(false) {
             it=last_write_times.erase(it);
         }
         if(update_paths.size()>0) {
-          dispatcher.add([this] {
+          dispatcher.push([this] {
             update_mutex.lock();
             for(auto &path: update_paths) {
               if(last_write_times.count(path)>0)

--- a/src/directories.cc
+++ b/src/directories.cc
@@ -22,6 +22,8 @@ namespace sigc {
 }
 
 Directories::Directories() : Gtk::TreeView(), stop_update_thread(false) {
+  this->set_enable_tree_lines(true);
+  
   tree_store = Gtk::TreeStore::create(column_record);
   set_model(tree_store);
   append_column("", column_record.name);

--- a/src/directories.h
+++ b/src/directories.h
@@ -9,6 +9,7 @@
 #include <thread>
 #include <mutex>
 #include <atomic>
+#include "dispatcher.h"
 
 class Directories : public Gtk::TreeView {
 public:
@@ -51,7 +52,7 @@ private:
   std::mutex update_mutex;
   std::thread update_thread;
   std::atomic<bool> stop_update_thread;
-  Glib::Dispatcher update_dispatcher;
+  Dispatcher dispatcher;
   std::vector<std::string> update_paths;
 };
 

--- a/src/dispatcher.cc
+++ b/src/dispatcher.cc
@@ -18,7 +18,7 @@ Dispatcher::~Dispatcher() {
   functions_mutex.unlock();
 }
 
-void Dispatcher::add(std::function<void()> function) {
+void Dispatcher::push(std::function<void()> &&function) {
   functions_mutex.lock();
   functions.emplace_back(function);
   functions_mutex.unlock();

--- a/src/dispatcher.cc
+++ b/src/dispatcher.cc
@@ -1,0 +1,30 @@
+#include "dispatcher.h"
+
+Dispatcher::Dispatcher() {
+  connection=dispatcher.connect([this] {
+    functions_mutex.lock();
+    for(auto &function: functions) {
+      function();
+    }
+    functions.clear();
+    functions_mutex.unlock();
+  });
+}
+
+Dispatcher::~Dispatcher() {
+  disconnect();
+  functions_mutex.lock();
+  functions.clear();
+  functions_mutex.unlock();
+}
+
+void Dispatcher::add(std::function<void()> function) {
+  functions_mutex.lock();
+  functions.emplace_back(function);
+  functions_mutex.unlock();
+  dispatcher();
+}
+
+void Dispatcher::disconnect() {
+  connection.disconnect();
+}

--- a/src/dispatcher.h
+++ b/src/dispatcher.h
@@ -1,0 +1,20 @@
+#ifndef DISPATCHER_H_
+#define	DISPATCHER_H_
+#include <gtkmm.h>
+#include <mutex>
+#include <vector>
+
+class Dispatcher {
+private:
+  std::vector<std::function<void()>> functions;
+  std::mutex functions_mutex;
+  Glib::Dispatcher dispatcher;
+  sigc::connection connection;
+public:
+  Dispatcher();
+  ~Dispatcher();
+  void add(std::function<void()> function);
+  void disconnect();
+};
+
+#endif	/* DISPATCHER_H_ */

--- a/src/dispatcher.h
+++ b/src/dispatcher.h
@@ -13,7 +13,7 @@ private:
 public:
   Dispatcher();
   ~Dispatcher();
-  void add(std::function<void()> function);
+  void push(std::function<void()> &&function);
   void disconnect();
 };
 

--- a/src/files.h
+++ b/src/files.h
@@ -125,7 +125,7 @@ const std::string configjson =
 "        \"debug_build_path_comment\": \"Use <project_directory_name> to insert the project top level directory name, and <default_build_path> to insert your default_build_path setting.\",\n"
 "        \"debug_build_path\": \"<default_build_path>/debug\",\n"
 #ifdef _WIN32
-"        \"cmake_command\": \"cmake -G\\\"MSYS Makefiles\\\" -DCMAKE_INSTALL_PREFIX="+JUCI_CMAKE_INSTALL_PREFIX+"\",\n"
+"        \"cmake_command\": \"cmake -G\\\"MSYS Makefiles\\\"\",\n"
 #else
 "        \"cmake_command\": \"cmake\",\n"
 #endif

--- a/src/juci.cc
+++ b/src/juci.cc
@@ -1,5 +1,6 @@
 #include "juci.h"
 #include "window.h"
+#include "notebook.h"
 #include "directories.h"
 #include "menu.h"
 #include "config.h"
@@ -68,7 +69,7 @@ void Application::on_activate() {
   }
   
   for(auto &file: files)
-    Window::get().notebook.open(file);
+    Notebook::get().open(file);
   
   for(auto &error: errors)
     Terminal::get().print(error, true);

--- a/src/juci.cc
+++ b/src/juci.cc
@@ -80,16 +80,12 @@ void Application::on_startup() {
   
   Menu::get().build();
 
-  auto object = Menu::get().builder->get_object("juci-menu");
-  auto juci_menu = Glib::RefPtr<Gio::Menu>::cast_dynamic(object);
-  object = Menu::get().builder->get_object("window-menu");
-  auto window_menu = Glib::RefPtr<Gio::Menu>::cast_dynamic(object);
-  if (!juci_menu || !window_menu) {
+  if (!Menu::get().juci_menu || !Menu::get().window_menu) {
     std::cerr << "Menu not found." << std::endl;
   }
   else {
-    set_app_menu(juci_menu);
-    set_menubar(window_menu);
+    set_app_menu(Menu::get().juci_menu);
+    set_menubar(Menu::get().window_menu);
   }
 }
 

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -404,6 +404,10 @@ void Menu::build() {
   
   try {
     builder->add_from_string(ui_xml);
+    auto object = Menu::get().builder->get_object("juci-menu");
+    juci_menu = Glib::RefPtr<Gio::Menu>::cast_dynamic(object);
+    object = Menu::get().builder->get_object("window-menu");
+    window_menu = Glib::RefPtr<Gio::Menu>::cast_dynamic(object);
   }
   catch (const Glib::Error &ex) {
     std::cerr << "building menu failed: " << ex.what();

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -7,7 +7,7 @@
 Menu::Menu() {
   auto accels=Config::get().menu.keys;
   for(auto &accel: accels) {
-#ifdef JUCI_UBUNTU_BUGGED_MENU
+#ifdef JUCI_UBUNTU
     size_t pos=0;
     std::string second=accel.second;
     while((pos=second.find('<', pos))!=std::string::npos) {

--- a/src/menu.h
+++ b/src/menu.h
@@ -19,8 +19,12 @@ public:
   void set_keys();
   
   void build();
-  Glib::RefPtr<Gtk::Builder> builder;
   
+  Glib::RefPtr<Gio::Menu> juci_menu;
+  Glib::RefPtr<Gio::Menu> window_menu;
+  
+private:
+  Glib::RefPtr<Gtk::Builder> builder;
   std::string ui_xml;
 };
 #endif  // JUCI_MENU_H_

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -48,8 +48,9 @@ Notebook::Notebook() : Gtk::Notebook(), last_index(-1) {
   Gsv::init();
   
   auto provider = Gtk::CssProvider::create();
-  provider->load_from_data(".notebook {padding: 0px; -GtkNotebook-tab-overlap: 0px;} .notebook tab {padding: 4px;}");
+  provider->load_from_data(".notebook {padding: 0px; -GtkNotebook-tab-overlap: 0px;} .notebook tab {border-radius: 5px;padding: 4px;}");
   get_style_context()->add_provider(provider, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+  get_style_context()->set_junction_sides(Gtk::JunctionSides::JUNCTION_BOTTOM);
   
   signal_switch_page().connect([this](Gtk::Widget* page, guint page_num) {
     last_index=-1;

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -47,7 +47,6 @@ Notebook::TabLabel::TabLabel(const std::string &title) : Gtk::Box(Gtk::ORIENTATI
 Notebook::Notebook() : Gtk::Notebook(), last_index(-1) {
   Gsv::init();
   
-  //Ubuntu forces its own theme
   auto provider = Gtk::CssProvider::create();
   provider->load_from_data(".notebook {padding: 0px; -GtkNotebook-tab-overlap: 0px;} .notebook tab {padding: 4px;}");
   get_style_context()->add_provider(provider, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -354,6 +354,14 @@ boost::filesystem::path Notebook::get_current_folder() {
   return current_path;
 }
 
+std::unique_ptr<Project> Notebook::get_project() {
+  boost::filesystem::path file_path;
+  if(get_current_page()!=-1)
+    file_path=get_current_view()->file_path;
+  
+  return std::unique_ptr<Project>(new ProjectClang(file_path));
+}
+
 bool Notebook::save_modified_dialog(int page) {
   Gtk::MessageDialog dialog((Gtk::Window&)(*get_toplevel()), "Save file!", false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO);
   dialog.set_default_response(Gtk::RESPONSE_YES);

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -32,6 +32,7 @@ Notebook::TabLabel::TabLabel(const std::string &title) : Gtk::Box(Gtk::ORIENTATI
   button.set_image_from_icon_name("window-close-symbolic", Gtk::ICON_SIZE_MENU);
   button.set_can_focus(false);
   button.set_relief(Gtk::ReliefStyle::RELIEF_NONE);
+  
   //Based on http://www.micahcarrick.com/gtk-notebook-tabs-with-close-button.html
   std::string data =  ".button {\n"
                       "-GtkButton-default-border : 0px;\n"
@@ -41,11 +42,17 @@ Notebook::TabLabel::TabLabel(const std::string &title) : Gtk::Box(Gtk::ORIENTATI
                       "-GtkWidget-focus-padding : 0px;\n"
                       "padding: 0px;\n"
                       "}";
-  auto provider = Gtk::CssProvider::create();
-  provider->load_from_data(data);
-  button.get_style_context()->add_provider(provider, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+  auto provider_button = Gtk::CssProvider::create();
+  provider_button->load_from_data(data);
+  button.get_style_context()->add_provider(provider_button, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+  
+  auto provider_label = Gtk::CssProvider::create();
+  provider_label->load_from_data(".label {padding: 7px;}");
+  label.get_style_context()->add_provider(provider_label, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+  
   pack_start(label, Gtk::PACK_SHRINK);
   pack_end(button, Gtk::PACK_SHRINK);
+  
   show_all();
 }
 
@@ -54,11 +61,7 @@ Notebook::Notebook() : Gtk::Notebook(), last_index(-1) {
   
   //Ubuntu forces its own theme
   std::string data =  ".notebook {\n"
-#ifdef JUCI_UBUNTU
-                      "padding: 1px;\n"
-#else
-                      "padding: 4px;\n"
-#endif
+                      "padding: 0px;\n"
                       "-GtkNotebook-tab-overlap: 0px;\n"
                       "-GtkNotebook-show-border: 0;\n"
                       "}";

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -54,6 +54,8 @@ Notebook::Notebook() : Gtk::Notebook(), last_index(-1) {
   
   std::string data =  ".notebook {\n"
                       "padding: 4px;\n"
+                      "-GtkNotebook-tab-overlap: 0px;\n"
+                      "-GtkNotebook-show-border: 0;\n"
                       "}";
   auto provider = Gtk::CssProvider::create();
   provider->load_from_data(data);

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -52,8 +52,13 @@ Notebook::TabLabel::TabLabel(const std::string &title) : Gtk::Box(Gtk::ORIENTATI
 Notebook::Notebook() : Gtk::Notebook(), last_index(-1) {
   Gsv::init();
   
+  //Ubuntu forces its own theme
   std::string data =  ".notebook {\n"
+#ifdef JUCI_UBUNTU
+                      "padding: 1px;\n"
+#else
                       "padding: 4px;\n"
+#endif
                       "-GtkNotebook-tab-overlap: 0px;\n"
                       "-GtkNotebook-show-border: 0;\n"
                       "}";

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -354,21 +354,6 @@ boost::filesystem::path Notebook::get_current_folder() {
   return current_path;
 }
 
-std::unique_ptr<Project> Notebook::get_project() {
-  if(get_current_page()!=-1) {
-    if(get_current_view()->language->get_id()=="markdown")
-      return std::unique_ptr<Project>(new ProjectMarkdown(*this));
-    if(get_current_view()->language->get_id()=="python")
-      return std::unique_ptr<Project>(new ProjectPython(*this));
-    if(get_current_view()->language->get_id()=="js")
-      return std::unique_ptr<Project>(new ProjectJavaScript(*this));
-    if(get_current_view()->language->get_id()=="html")
-      return std::unique_ptr<Project>(new ProjectHTML(*this));
-  }
-  
-  return std::unique_ptr<Project>(new ProjectClang(*this));
-}
-
 bool Notebook::save_modified_dialog(int page) {
   Gtk::MessageDialog dialog((Gtk::Window&)(*get_toplevel()), "Save file!", false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO);
   dialog.set_default_response(Gtk::RESPONSE_YES);

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -356,9 +356,12 @@ boost::filesystem::path Notebook::get_current_folder() {
 
 std::unique_ptr<Project> Notebook::get_project() {
   if(get_current_page()!=-1) {
-    if(get_current_view()->language->get_id()=="markdown") {
-      return std::unique_ptr<Project>(new ProjectMarkDown(*this));
-    }
+    if(get_current_view()->language->get_id()=="markdown")
+      return std::unique_ptr<Project>(new ProjectMarkdown(*this));
+    if(get_current_view()->language->get_id()=="python")
+      return std::unique_ptr<Project>(new ProjectPython(*this));
+    if(get_current_view()->language->get_id()=="js")
+      return std::unique_ptr<Project>(new ProjectJavaScript(*this));
   }
   
   return std::unique_ptr<Project>(new ProjectClang(*this));

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -355,17 +355,13 @@ boost::filesystem::path Notebook::get_current_folder() {
 }
 
 std::unique_ptr<Project> Notebook::get_project() {
-  boost::filesystem::path file_path;
-  if(get_current_page()!=-1)
-    file_path=get_current_view()->file_path;
-  
   if(get_current_page()!=-1) {
     if(get_current_view()->language->get_id()=="markdown") {
-      return std::unique_ptr<Project>(new ProjectMarkDown(file_path));
+      return std::unique_ptr<Project>(new ProjectMarkDown(*this));
     }
   }
   
-  return std::unique_ptr<Project>(new ProjectClang(file_path));
+  return std::unique_ptr<Project>(new ProjectClang(*this));
 }
 
 bool Notebook::save_modified_dialog(int page) {

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -27,29 +27,17 @@ namespace sigc {
 
 Notebook::TabLabel::TabLabel(const std::string &title) : Gtk::Box(Gtk::ORIENTATION_HORIZONTAL) {
   set_can_focus(false);
-  label.set_text(title);
+  label.set_text(title+' ');
   label.set_can_focus(false);
   button.set_image_from_icon_name("window-close-symbolic", Gtk::ICON_SIZE_MENU);
   button.set_can_focus(false);
   button.set_relief(Gtk::ReliefStyle::RELIEF_NONE);
   
   //Based on http://www.micahcarrick.com/gtk-notebook-tabs-with-close-button.html
-  std::string data =  ".button {\n"
-                      "-GtkButton-default-border : 0px;\n"
-                      "-GtkButton-default-outside-border : 0px;\n"
-                      "-GtkButton-inner-border: 0px;\n"
-                      "-GtkWidget-focus-line-width : 0px;\n"
-                      "-GtkWidget-focus-padding : 0px;\n"
-                      "padding: 0px;\n"
-                      "}";
-  auto provider_button = Gtk::CssProvider::create();
-  provider_button->load_from_data(data);
-  button.get_style_context()->add_provider(provider_button, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-  
-  auto provider_label = Gtk::CssProvider::create();
-  provider_label->load_from_data(".label {padding: 7px;}");
-  label.get_style_context()->add_provider(provider_label, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-  
+  auto provider = Gtk::CssProvider::create();
+  provider->load_from_data(".button {border: 0px; outline-width: 0px; margin: 0px; padding: 0px;}");
+  button.get_style_context()->add_provider(provider, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+    
   pack_start(label, Gtk::PACK_SHRINK);
   pack_end(button, Gtk::PACK_SHRINK);
   
@@ -60,13 +48,8 @@ Notebook::Notebook() : Gtk::Notebook(), last_index(-1) {
   Gsv::init();
   
   //Ubuntu forces its own theme
-  std::string data =  ".notebook {\n"
-                      "padding: 0px;\n"
-                      "-GtkNotebook-tab-overlap: 0px;\n"
-                      "-GtkNotebook-show-border: 0;\n"
-                      "}";
   auto provider = Gtk::CssProvider::create();
-  provider->load_from_data(data);
+  provider->load_from_data(".notebook {padding: 0px; -GtkNotebook-tab-overlap: 0px;} .notebook tab {padding: 4px;}");
   get_style_context()->add_provider(provider, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
   
   signal_switch_page().connect([this](Gtk::Widget* page, guint page_num) {
@@ -183,7 +166,9 @@ void Notebook::open(const boost::filesystem::path &file_path) {
   get_current_view()->get_buffer()->signal_modified_changed().connect([this, source_view]() {
     std::string title=source_view->file_path.filename().string();
     if(source_view->get_buffer()->get_modified())
-      title+="*";
+      title+='*';
+    else
+      title+=' ';
     int page=-1;
     for(int c=0;c<size();c++) {
       if(get_view(c)==source_view) {

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -52,6 +52,13 @@ Notebook::TabLabel::TabLabel(const std::string &title) : Gtk::Box(Gtk::ORIENTATI
 Notebook::Notebook() : Gtk::Notebook(), last_index(-1) {
   Gsv::init();
   
+  std::string data =  ".notebook {\n"
+                      "padding: 4px;\n"
+                      "}";
+  auto provider = Gtk::CssProvider::create();
+  provider->load_from_data(data);
+  get_style_context()->add_provider(provider, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+  
   signal_switch_page().connect([this](Gtk::Widget* page, guint page_num) {
     last_index=-1;
   });

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -362,6 +362,8 @@ std::unique_ptr<Project> Notebook::get_project() {
       return std::unique_ptr<Project>(new ProjectPython(*this));
     if(get_current_view()->language->get_id()=="js")
       return std::unique_ptr<Project>(new ProjectJavaScript(*this));
+    if(get_current_view()->language->get_id()=="html")
+      return std::unique_ptr<Project>(new ProjectHTML(*this));
   }
   
   return std::unique_ptr<Project>(new ProjectClang(*this));

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -359,6 +359,12 @@ std::unique_ptr<Project> Notebook::get_project() {
   if(get_current_page()!=-1)
     file_path=get_current_view()->file_path;
   
+  if(get_current_page()!=-1) {
+    if(get_current_view()->language->get_id()=="markdown") {
+      return std::unique_ptr<Project>(new ProjectMarkDown(file_path));
+    }
+  }
+  
   return std::unique_ptr<Project>(new ProjectClang(file_path));
 }
 
@@ -378,4 +384,3 @@ bool Notebook::save_modified_dialog(int page) {
     return false;
   }
 }
-

--- a/src/notebook.h
+++ b/src/notebook.h
@@ -10,6 +10,8 @@
 #include <map>
 #include <sigc++/sigc++.h>
 
+class Project; //Avoiding this would lead to bloated code
+
 class Notebook : public Gtk::Notebook {
   class TabLabel : public Gtk::Box {
   public:

--- a/src/notebook.h
+++ b/src/notebook.h
@@ -16,8 +16,15 @@ class Notebook : public Gtk::Notebook {
     Gtk::Label label;
     Gtk::Button button;
   };
-public:
+  
+private:
   Notebook();
+public:
+  static Notebook &get() {
+    static Notebook singleton;
+    return singleton;
+  }
+  
   Source::View* get_view(int page);
   size_t get_index(int page);
   int size();

--- a/src/notebook.h
+++ b/src/notebook.h
@@ -5,6 +5,7 @@
 #include "gtkmm.h"
 #include "source.h"
 #include "source_clang.h"
+#include "project.h"
 #include <type_traits>
 #include <map>
 #include <sigc++/sigc++.h>
@@ -30,6 +31,7 @@ public:
   void save_project_files();
   void configure(int view_nr);
   boost::filesystem::path get_current_folder();
+  std::unique_ptr<Project> get_project();
 
   Gtk::Label info;
   Gtk::Label status;

--- a/src/notebook.h
+++ b/src/notebook.h
@@ -5,12 +5,9 @@
 #include "gtkmm.h"
 #include "source.h"
 #include "source_clang.h"
-#include "project.h"
 #include <type_traits>
 #include <map>
 #include <sigc++/sigc++.h>
-
-class Project; //Avoiding this would lead to bloated code
 
 class Notebook : public Gtk::Notebook {
   class TabLabel : public Gtk::Box {
@@ -33,7 +30,6 @@ public:
   void save_project_files();
   void configure(int view_nr);
   boost::filesystem::path get_current_folder();
-  std::unique_ptr<Project> get_project();
 
   Gtk::Label info;
   Gtk::Label status;

--- a/src/project.cc
+++ b/src/project.cc
@@ -3,6 +3,9 @@
 #include "terminal.h"
 #include "filesystem.h"
 #include <fstream>
+#ifdef JUCI_ENABLE_DEBUG
+#include "debug.h"
+#endif
 
 std::unordered_map<std::string, std::string> Project::run_arguments;
 std::unordered_map<std::string, std::string> Project::debug_run_arguments;
@@ -11,8 +14,8 @@ std::atomic<bool> Project::debugging(false);
 
 std::unique_ptr<CMake> ProjectClang::get_cmake() {
   boost::filesystem::path path;
-  if(!file_path.empty())
-    path=file_path.parent_path();
+  if(notebook.get_current_page()!=-1)
+    path=notebook.get_current_view()->file_path.parent_path();
   else
     path=Directories::get().current_path;
   if(path.empty())
@@ -37,15 +40,15 @@ std::pair<std::string, std::string> ProjectClang::get_run_arguments() {
     arguments=run_arguments_it->second;
   
   if(arguments.empty()) {
-    auto executable=cmake->get_executable(file_path).string();
+    auto executable=cmake->get_executable(notebook.get_current_page()!=-1?notebook.get_current_view()->file_path:"").string();
     
     if(executable!="") {
       auto project_path=cmake->project_path;
-      auto default_build_path=CMake::get_default_build_path(project_path);
-      if(!default_build_path.empty()) {
+      auto build_path=CMake::get_default_build_path(project_path);
+      if(!build_path.empty()) {
         size_t pos=executable.find(project_path.string());
         if(pos!=std::string::npos)
-          executable.replace(pos, project_path.string().size(), default_build_path.string());
+          executable.replace(pos, project_path.string().size(), build_path.string());
       }
       arguments=filesystem::escape_argument(executable);
     }
@@ -87,7 +90,7 @@ void ProjectClang::compile_and_run() {
     arguments=run_arguments_it->second;
   
   if(arguments.empty()) {
-    arguments=cmake->get_executable(file_path).string();
+    arguments=cmake->get_executable(notebook.get_current_page()!=-1?notebook.get_current_view()->file_path:"").string();
     if(arguments.empty()) {
       Terminal::get().print("Could not find add_executable in the following paths:\n");
       for(auto &path: cmake->paths)
@@ -113,6 +116,271 @@ void ProjectClang::compile_and_run() {
   });
 }
 
+#ifdef JUCI_ENABLE_DEBUG
+std::pair<std::string, std::string> ProjectClang::debug_get_run_arguments() {
+  auto cmake=get_cmake();
+  if(!cmake)
+    return {"", ""};
+  
+  auto project_path=cmake->project_path.string();
+  auto run_arguments_it=debug_run_arguments.find(project_path);
+  std::string arguments;
+  if(run_arguments_it!=debug_run_arguments.end())
+    arguments=run_arguments_it->second;
+  
+  if(arguments.empty()) {
+    auto executable=cmake->get_executable(notebook.get_current_page()!=-1?notebook.get_current_view()->file_path:"").string();
+    
+    if(executable!="") {
+      auto project_path=cmake->project_path;
+      auto build_path=CMake::get_debug_build_path(project_path);
+      if(!build_path.empty()) {
+        size_t pos=executable.find(project_path.string());
+        if(pos!=std::string::npos)
+          executable.replace(pos, project_path.string().size(), build_path.string());
+      }
+      arguments=filesystem::escape_argument(executable);
+    }
+    else
+      arguments=filesystem::escape_argument(CMake::get_debug_build_path(cmake->project_path));
+  }
+  
+  return {project_path, arguments};
+}
+
+void ProjectClang::debug_start(std::function<void(const std::string &status)> status_callback,
+                               std::function<void(const boost::filesystem::path &file_path, int line_nr, int line_index)> stop_callback) {
+  auto cmake=get_cmake();
+  if(!cmake)
+    return;
+  auto project_path=cmake->project_path;
+      
+  auto debug_build_path=CMake::get_debug_build_path(project_path);
+  if(debug_build_path.empty())
+    return;
+  if(!CMake::create_debug_build(project_path))
+    return;
+  
+  auto run_arguments_it=debug_run_arguments.find(project_path.string());
+  std::string run_arguments;
+  if(run_arguments_it!=debug_run_arguments.end())
+    run_arguments=run_arguments_it->second;
+  
+  if(run_arguments.empty()) {
+    run_arguments=cmake->get_executable(notebook.get_current_page()!=-1?notebook.get_current_view()->file_path:"").string();
+    if(run_arguments.empty()) {
+      Terminal::get().print("Could not find add_executable in the following paths:\n");
+      for(auto &path: cmake->paths)
+        Terminal::get().print("  "+path.string()+"\n");
+      Terminal::get().print("Solution: either use Debug Set Run Arguments, or open a source file within a directory where add_executable is set.\n", true);
+      return;
+    }
+    size_t pos=run_arguments.find(project_path.string());
+    if(pos!=std::string::npos)
+      run_arguments.replace(pos, project_path.string().size(), debug_build_path.string());
+    run_arguments=filesystem::escape_argument(run_arguments);
+  }
+  
+  auto breakpoints=std::make_shared<std::vector<std::pair<boost::filesystem::path, int> > >();
+  for(int c=0;c<notebook.size();c++) {
+    auto view=notebook.get_view(c);
+    if(project_path==view->project_path) {
+      auto iter=view->get_buffer()->begin();
+      if(view->get_source_buffer()->get_source_marks_at_iter(iter, "debug_breakpoint").size()>0)
+        breakpoints->emplace_back(view->file_path, iter.get_line()+1);
+      while(view->get_source_buffer()->forward_iter_to_source_mark(iter, "debug_breakpoint"))
+        breakpoints->emplace_back(view->file_path, iter.get_line()+1);
+    }
+  }
+  
+  debugging=true;
+  Terminal::get().print("Compiling and debugging "+run_arguments+"\n");
+  Terminal::get().async_process(Config::get().terminal.make_command, debug_build_path, [this, breakpoints, run_arguments, debug_build_path, status_callback, stop_callback](int exit_status){
+    if(exit_status!=EXIT_SUCCESS)
+      debugging=false;
+    else {
+      debug_start_mutex.lock();
+      Debug::get().start(run_arguments, debug_build_path, *breakpoints, [this, run_arguments](int exit_status){
+        debugging=false;
+        Terminal::get().async_print(run_arguments+" returned: "+std::to_string(exit_status)+'\n');
+      }, status_callback, stop_callback);
+      debug_start_mutex.unlock();
+    }
+  });
+}
+
+void ProjectClang::debug_continue() {
+  Debug::get().continue_debug();
+}
+
+void ProjectClang::debug_stop() {
+  if(debugging)
+    Debug::get().stop();
+}
+
+void ProjectClang::debug_kill() {
+  if(debugging)
+    Debug::get().kill();
+}
+
+void ProjectClang::debug_step_over() {
+  if(debugging)
+    Debug::get().step_over();
+}
+
+void ProjectClang::debug_step_into() {
+  if(debugging)
+    Debug::get().step_into();
+}
+
+void ProjectClang::debug_step_out() {
+  if(debugging)
+    Debug::get().step_out();
+}
+
+void ProjectClang::debug_backtrace() {
+  if(debugging && notebook.get_current_page()!=-1) {
+    auto backtrace=Debug::get().get_backtrace();
+    
+    auto view=notebook.get_current_view();
+    auto iter=view->get_iter_for_dialog();
+    view->selection_dialog=std::unique_ptr<SelectionDialog>(new SelectionDialog(*view, view->get_buffer()->create_mark(iter), true, true));
+    auto rows=std::make_shared<std::unordered_map<std::string, Debug::Frame> >();
+    if(backtrace.size()==0)
+      return;
+    
+    for(auto &frame: backtrace) {
+      std::string row="<i>"+frame.module_filename+"</i>";
+      
+      //Shorten frame.function_name if it is too long
+      if(frame.function_name.size()>120) {
+        frame.function_name=frame.function_name.substr(0, 58)+"...."+frame.function_name.substr(frame.function_name.size()-58);
+      }
+      if(frame.file_path.empty())
+        row+=" - "+Glib::Markup::escape_text(frame.function_name);
+      else {
+        auto file_path=boost::filesystem::path(frame.file_path).filename().string();
+        row+=":<b>"+Glib::Markup::escape_text(file_path)+":"+std::to_string(frame.line_nr)+"</b> - "+Glib::Markup::escape_text(frame.function_name);
+      }
+      (*rows)[row]=frame;
+      view->selection_dialog->add_row(row);
+    }
+    
+    view->selection_dialog->on_select=[this, rows](const std::string& selected, bool hide_window) {
+      auto frame=rows->at(selected);
+      if(!frame.file_path.empty()) {
+        notebook.open(frame.file_path);
+        if(notebook.get_current_page()!=-1) {
+          auto view=notebook.get_current_view();
+          
+          Debug::get().select_frame(frame.index);
+          
+          view->get_buffer()->place_cursor(view->get_buffer()->get_iter_at_line_index(frame.line_nr-1, frame.line_index-1));
+          
+          while(g_main_context_pending(NULL))
+            g_main_context_iteration(NULL, false);
+          if(notebook.get_current_page()!=-1 && notebook.get_current_view()==view)
+            view->scroll_to(view->get_buffer()->get_insert(), 0.0, 1.0, 0.5);
+        }
+      }
+    };
+    view->selection_dialog->show();
+  }
+}
+
+void ProjectClang::debug_show_variables() {
+  if(debugging && notebook.get_current_page()!=-1) {
+    auto variables=Debug::get().get_variables();
+    
+    auto view=notebook.get_current_view();
+    auto iter=view->get_iter_for_dialog();
+    view->selection_dialog=std::unique_ptr<SelectionDialog>(new SelectionDialog(*view, view->get_buffer()->create_mark(iter), true, true));
+    auto rows=std::make_shared<std::unordered_map<std::string, Debug::Variable> >();
+    if(variables.size()==0)
+      return;
+    
+    for(auto &variable: variables) {
+      std::string row="#"+std::to_string(variable.thread_index_id)+":#"+std::to_string(variable.frame_index)+":"+variable.file_path.filename().string()+":"+std::to_string(variable.line_nr)+" - <b>"+Glib::Markup::escape_text(variable.name)+"</b>";
+      
+      (*rows)[row]=variable;
+      view->selection_dialog->add_row(row);
+    }
+    
+    view->selection_dialog->on_select=[this, rows](const std::string& selected, bool hide_window) {
+      auto variable=rows->at(selected);
+      if(!variable.file_path.empty()) {
+        notebook.open(variable.file_path);
+        if(notebook.get_current_page()!=-1) {
+          auto view=notebook.get_current_view();
+          
+          Debug::get().select_frame(variable.frame_index, variable.thread_index_id);
+          
+          view->get_buffer()->place_cursor(view->get_buffer()->get_iter_at_line_index(variable.line_nr-1, variable.line_index-1));
+          
+          while(g_main_context_pending(NULL))
+            g_main_context_iteration(NULL, false);
+          if(notebook.get_current_page()!=-1 && notebook.get_current_view()==view)
+            view->scroll_to(view->get_buffer()->get_insert(), 0.0, 1.0, 0.5);
+        }
+      }
+    };
+    
+    view->selection_dialog->on_hide=[this]() {
+      debug_variable_tooltips.hide();
+      debug_variable_tooltips.clear();
+    };
+    
+    view->selection_dialog->on_changed=[this, rows, iter](const std::string &selected) {
+      if(selected.empty()) {
+        debug_variable_tooltips.hide();
+        return;
+      }
+      if(notebook.get_current_page()!=-1) {
+        auto view=notebook.get_current_view();
+        debug_variable_tooltips.clear();
+        auto create_tooltip_buffer=[this, rows, view, selected]() {
+          auto variable=rows->at(selected);
+          auto tooltip_buffer=Gtk::TextBuffer::create(view->get_buffer()->get_tag_table());
+          
+          Glib::ustring value=variable.value;
+          if(!value.empty()) {
+            Glib::ustring::iterator iter;
+            while(!value.validate(iter)) {
+              auto next_char_iter=iter;
+              next_char_iter++;
+              value.replace(iter, next_char_iter, "?");
+            } 
+            tooltip_buffer->insert_with_tag(tooltip_buffer->get_insert()->get_iter(), value.substr(0, value.size()-1), "def:note");
+          }
+          
+          return tooltip_buffer;
+        };
+        
+        debug_variable_tooltips.emplace_back(create_tooltip_buffer, *view, view->get_buffer()->create_mark(iter), view->get_buffer()->create_mark(iter));
+    
+        debug_variable_tooltips.show(true);
+      }
+    };
+    
+    view->selection_dialog->show();
+  }
+}
+
+void ProjectClang::debug_run_command(const std::string &command) {
+  if(debugging) {
+    auto command_return=Debug::get().run_command(command);
+    Terminal::get().async_print(command_return.first);
+    Terminal::get().async_print(command_return.second, true);
+  }
+}
+
+void ProjectClang::debug_delete() {
+  debug_start_mutex.lock();
+  Debug::get().delete_debug();
+  debug_start_mutex.unlock();
+}
+#endif
+
 ProjectMarkDown::~ProjectMarkDown() {
   if(!last_temp_path.empty()) {
     boost::filesystem::remove(last_temp_path);
@@ -127,7 +395,7 @@ void ProjectMarkDown::compile_and_run() {
   }
   
   std::stringstream stdin_stream, stdout_stream;
-  auto exit_status=Terminal::get().process(stdin_stream, stdout_stream, "markdown "+file_path.string(), this->file_path.parent_path());
+  auto exit_status=Terminal::get().process(stdin_stream, stdout_stream, "markdown "+notebook.get_current_view()->file_path.string());
   if(exit_status==0) {
     boost::system::error_code ec;
     auto temp_path=boost::filesystem::temp_directory_path(ec);

--- a/src/project.cc
+++ b/src/project.cc
@@ -141,7 +141,7 @@ void Project::Clang::compile() {
     return;
   compiling=true;
   Terminal::get().print("Compiling project "+cmake->project_path.string()+"\n");
-  Terminal::get().async_process(Config::get().terminal.make_command, default_build_path, [this](int exit_status) {
+  Terminal::get().async_process(Config::get().project.make_command, default_build_path, [this](int exit_status) {
     compiling=false;
   });
 }
@@ -178,7 +178,7 @@ void Project::Clang::compile_and_run() {
   
   compiling=true;
   Terminal::get().print("Compiling and running "+arguments+"\n");
-  Terminal::get().async_process(Config::get().terminal.make_command, default_build_path, [this, arguments, default_build_path](int exit_status){
+  Terminal::get().async_process(Config::get().project.make_command, default_build_path, [this, arguments, default_build_path](int exit_status){
     compiling=false;
     if(exit_status==EXIT_SUCCESS) {
       Terminal::get().async_process(arguments, default_build_path, [this, arguments](int exit_status){
@@ -266,7 +266,7 @@ void Project::Clang::debug_start() {
   
   debugging=true;
   Terminal::get().print("Compiling and debugging "+run_arguments+"\n");
-  Terminal::get().async_process(Config::get().terminal.make_command, debug_build_path, [this, breakpoints, run_arguments, debug_build_path](int exit_status){
+  Terminal::get().async_process(Config::get().project.make_command, debug_build_path, [this, breakpoints, run_arguments, debug_build_path](int exit_status){
     if(exit_status!=EXIT_SUCCESS)
       debugging=false;
     else {

--- a/src/project.cc
+++ b/src/project.cc
@@ -16,6 +16,8 @@ std::atomic<bool> Project::debugging;
 std::pair<boost::filesystem::path, std::pair<int, int> > Project::debug_stop;
 boost::filesystem::path Project::debug_last_stop_file_path;
 
+std::unique_ptr<Project::Language> Project::current_language;
+
 void Project::debug_update_status(const std::string &debug_status) {
   if(debug_status.empty()) {
     debug_status_label().set_text("");
@@ -463,6 +465,14 @@ void Project::Clang::debug_add_breakpoint(const boost::filesystem::path &file_pa
 
 void Project::Clang::debug_remove_breakpoint(const boost::filesystem::path &file_path, int line_nr, int line_count) {
   DebugClang::get().remove_breakpoint(file_path, line_nr, line_count);
+}
+
+bool Project::Clang::debug_is_running() {
+  return DebugClang::get().is_running();
+}
+
+void Project::Clang::debug_write(const std::string &buffer) {
+  DebugClang::get().write(buffer);
 }
 
 void Project::Clang::debug_delete() {

--- a/src/project.cc
+++ b/src/project.cc
@@ -273,7 +273,7 @@ void Project::Clang::debug_start() {
       debugging=false;
     else {
       debug_start_mutex.lock();
-      DebugClang::get().start(run_arguments, debug_build_path, *breakpoints, [this, run_arguments](int exit_status){
+      Debug::Clang::get().start(run_arguments, debug_build_path, *breakpoints, [this, run_arguments](int exit_status){
         debugging=false;
         Terminal::get().async_print(run_arguments+" returned: "+std::to_string(exit_status)+'\n');
       }, [this](const std::string &status) {
@@ -295,42 +295,42 @@ void Project::Clang::debug_start() {
 }
 
 void Project::Clang::debug_continue() {
-  DebugClang::get().continue_debug();
+  Debug::Clang::get().continue_debug();
 }
 
 void Project::Clang::debug_stop() {
   if(debugging)
-    DebugClang::get().stop();
+    Debug::Clang::get().stop();
 }
 
 void Project::Clang::debug_kill() {
   if(debugging)
-    DebugClang::get().kill();
+    Debug::Clang::get().kill();
 }
 
 void Project::Clang::debug_step_over() {
   if(debugging)
-    DebugClang::get().step_over();
+    Debug::Clang::get().step_over();
 }
 
 void Project::Clang::debug_step_into() {
   if(debugging)
-    DebugClang::get().step_into();
+    Debug::Clang::get().step_into();
 }
 
 void Project::Clang::debug_step_out() {
   if(debugging)
-    DebugClang::get().step_out();
+    Debug::Clang::get().step_out();
 }
 
 void Project::Clang::debug_backtrace() {
   if(debugging && Notebook::get().get_current_page()!=-1) {
-    auto backtrace=DebugClang::get().get_backtrace();
+    auto backtrace=Debug::Clang::get().get_backtrace();
     
     auto view=Notebook::get().get_current_view();
     auto iter=view->get_iter_for_dialog();
     view->selection_dialog=std::unique_ptr<SelectionDialog>(new SelectionDialog(*view, view->get_buffer()->create_mark(iter), true, true));
-    auto rows=std::make_shared<std::unordered_map<std::string, DebugClang::Frame> >();
+    auto rows=std::make_shared<std::unordered_map<std::string, Debug::Clang::Frame> >();
     if(backtrace.size()==0)
       return;
     
@@ -358,7 +358,7 @@ void Project::Clang::debug_backtrace() {
         if(Notebook::get().get_current_page()!=-1) {
           auto view=Notebook::get().get_current_view();
           
-          DebugClang::get().select_frame(frame.index);
+          Debug::Clang::get().select_frame(frame.index);
           
           view->get_buffer()->place_cursor(view->get_buffer()->get_iter_at_line_index(frame.line_nr-1, frame.line_index-1));
           
@@ -375,12 +375,12 @@ void Project::Clang::debug_backtrace() {
 
 void Project::Clang::debug_show_variables() {
   if(debugging && Notebook::get().get_current_page()!=-1) {
-    auto variables=DebugClang::get().get_variables();
+    auto variables=Debug::Clang::get().get_variables();
     
     auto view=Notebook::get().get_current_view();
     auto iter=view->get_iter_for_dialog();
     view->selection_dialog=std::unique_ptr<SelectionDialog>(new SelectionDialog(*view, view->get_buffer()->create_mark(iter), true, true));
-    auto rows=std::make_shared<std::unordered_map<std::string, DebugClang::Variable> >();
+    auto rows=std::make_shared<std::unordered_map<std::string, Debug::Clang::Variable> >();
     if(variables.size()==0)
       return;
     
@@ -398,7 +398,7 @@ void Project::Clang::debug_show_variables() {
         if(Notebook::get().get_current_page()!=-1) {
           auto view=Notebook::get().get_current_view();
           
-          DebugClang::get().select_frame(variable.frame_index, variable.thread_index_id);
+          Debug::Clang::get().select_frame(variable.frame_index, variable.thread_index_id);
           
           view->get_buffer()->place_cursor(view->get_buffer()->get_iter_at_line_index(variable.line_nr-1, variable.line_index-1));
           
@@ -453,31 +453,31 @@ void Project::Clang::debug_show_variables() {
 
 void Project::Clang::debug_run_command(const std::string &command) {
   if(debugging) {
-    auto command_return=DebugClang::get().run_command(command);
+    auto command_return=Debug::Clang::get().run_command(command);
     Terminal::get().async_print(command_return.first);
     Terminal::get().async_print(command_return.second, true);
   }
 }
 
 void Project::Clang::debug_add_breakpoint(const boost::filesystem::path &file_path, int line_nr) {
-  DebugClang::get().add_breakpoint(file_path, line_nr);
+  Debug::Clang::get().add_breakpoint(file_path, line_nr);
 }
 
 void Project::Clang::debug_remove_breakpoint(const boost::filesystem::path &file_path, int line_nr, int line_count) {
-  DebugClang::get().remove_breakpoint(file_path, line_nr, line_count);
+  Debug::Clang::get().remove_breakpoint(file_path, line_nr, line_count);
 }
 
 bool Project::Clang::debug_is_running() {
-  return DebugClang::get().is_running();
+  return Debug::Clang::get().is_running();
 }
 
 void Project::Clang::debug_write(const std::string &buffer) {
-  DebugClang::get().write(buffer);
+  Debug::Clang::get().write(buffer);
 }
 
 void Project::Clang::debug_delete() {
   debug_start_mutex.lock();
-  DebugClang::get().delete_debug();
+  Debug::Clang::get().delete_debug();
   debug_start_mutex.unlock();
 }
 #endif

--- a/src/project.cc
+++ b/src/project.cc
@@ -407,7 +407,15 @@ void ProjectMarkdown::compile_and_run() {
         std::ofstream file_stream(temp_path.string(), std::fstream::binary);
         file_stream << stdout_stream.rdbuf();
         file_stream.close();
-        Terminal::get().async_process("open "+temp_path.string());
+        
+        auto uri=temp_path.string();
+#ifdef __APPLE__
+        Terminal::get().process("open \""+uri+"\"");
+#else
+        GError* error=NULL;
+        gtk_show_uri(NULL, uri.c_str(), GDK_CURRENT_TIME, &error);
+        g_clear_error(&error);
+#endif
       }
     }
   }
@@ -427,4 +435,15 @@ void ProjectJavaScript::compile_and_run() {
   Terminal::get().async_process(command, notebook.get_current_view()->file_path.parent_path(), [command](int exit_status) {
     Terminal::get().async_print(command+" returned: "+std::to_string(exit_status)+'\n');
   });
+}
+
+void ProjectHTML::compile_and_run() {
+  auto uri=notebook.get_current_view()->file_path.string();
+#ifdef __APPLE__
+  Terminal::get().process("open \""+uri+"\"");
+#else
+  GError* error=NULL;
+  gtk_show_uri(NULL, uri.c_str(), GDK_CURRENT_TIME, &error);
+  g_clear_error(&error);
+#endif
 }

--- a/src/project.cc
+++ b/src/project.cc
@@ -6,7 +6,7 @@
 #include "menu.h"
 #include "notebook.h"
 #ifdef JUCI_ENABLE_DEBUG
-#include "debug.h"
+#include "debug_clang.h"
 #endif
 
 std::unordered_map<std::string, std::string> Project::run_arguments;
@@ -271,7 +271,7 @@ void Project::Clang::debug_start() {
       debugging=false;
     else {
       debug_start_mutex.lock();
-      Debug::get().start(run_arguments, debug_build_path, *breakpoints, [this, run_arguments](int exit_status){
+      DebugClang::get().start(run_arguments, debug_build_path, *breakpoints, [this, run_arguments](int exit_status){
         debugging=false;
         Terminal::get().async_print(run_arguments+" returned: "+std::to_string(exit_status)+'\n');
       }, [this](const std::string &status) {
@@ -293,42 +293,42 @@ void Project::Clang::debug_start() {
 }
 
 void Project::Clang::debug_continue() {
-  Debug::get().continue_debug();
+  DebugClang::get().continue_debug();
 }
 
 void Project::Clang::debug_stop() {
   if(debugging)
-    Debug::get().stop();
+    DebugClang::get().stop();
 }
 
 void Project::Clang::debug_kill() {
   if(debugging)
-    Debug::get().kill();
+    DebugClang::get().kill();
 }
 
 void Project::Clang::debug_step_over() {
   if(debugging)
-    Debug::get().step_over();
+    DebugClang::get().step_over();
 }
 
 void Project::Clang::debug_step_into() {
   if(debugging)
-    Debug::get().step_into();
+    DebugClang::get().step_into();
 }
 
 void Project::Clang::debug_step_out() {
   if(debugging)
-    Debug::get().step_out();
+    DebugClang::get().step_out();
 }
 
 void Project::Clang::debug_backtrace() {
   if(debugging && Notebook::get().get_current_page()!=-1) {
-    auto backtrace=Debug::get().get_backtrace();
+    auto backtrace=DebugClang::get().get_backtrace();
     
     auto view=Notebook::get().get_current_view();
     auto iter=view->get_iter_for_dialog();
     view->selection_dialog=std::unique_ptr<SelectionDialog>(new SelectionDialog(*view, view->get_buffer()->create_mark(iter), true, true));
-    auto rows=std::make_shared<std::unordered_map<std::string, Debug::Frame> >();
+    auto rows=std::make_shared<std::unordered_map<std::string, DebugClang::Frame> >();
     if(backtrace.size()==0)
       return;
     
@@ -356,7 +356,7 @@ void Project::Clang::debug_backtrace() {
         if(Notebook::get().get_current_page()!=-1) {
           auto view=Notebook::get().get_current_view();
           
-          Debug::get().select_frame(frame.index);
+          DebugClang::get().select_frame(frame.index);
           
           view->get_buffer()->place_cursor(view->get_buffer()->get_iter_at_line_index(frame.line_nr-1, frame.line_index-1));
           
@@ -373,12 +373,12 @@ void Project::Clang::debug_backtrace() {
 
 void Project::Clang::debug_show_variables() {
   if(debugging && Notebook::get().get_current_page()!=-1) {
-    auto variables=Debug::get().get_variables();
+    auto variables=DebugClang::get().get_variables();
     
     auto view=Notebook::get().get_current_view();
     auto iter=view->get_iter_for_dialog();
     view->selection_dialog=std::unique_ptr<SelectionDialog>(new SelectionDialog(*view, view->get_buffer()->create_mark(iter), true, true));
-    auto rows=std::make_shared<std::unordered_map<std::string, Debug::Variable> >();
+    auto rows=std::make_shared<std::unordered_map<std::string, DebugClang::Variable> >();
     if(variables.size()==0)
       return;
     
@@ -396,7 +396,7 @@ void Project::Clang::debug_show_variables() {
         if(Notebook::get().get_current_page()!=-1) {
           auto view=Notebook::get().get_current_view();
           
-          Debug::get().select_frame(variable.frame_index, variable.thread_index_id);
+          DebugClang::get().select_frame(variable.frame_index, variable.thread_index_id);
           
           view->get_buffer()->place_cursor(view->get_buffer()->get_iter_at_line_index(variable.line_nr-1, variable.line_index-1));
           
@@ -451,23 +451,23 @@ void Project::Clang::debug_show_variables() {
 
 void Project::Clang::debug_run_command(const std::string &command) {
   if(debugging) {
-    auto command_return=Debug::get().run_command(command);
+    auto command_return=DebugClang::get().run_command(command);
     Terminal::get().async_print(command_return.first);
     Terminal::get().async_print(command_return.second, true);
   }
 }
 
 void Project::Clang::debug_add_breakpoint(const boost::filesystem::path &file_path, int line_nr) {
-  Debug::get().add_breakpoint(file_path, line_nr);
+  DebugClang::get().add_breakpoint(file_path, line_nr);
 }
 
 void Project::Clang::debug_remove_breakpoint(const boost::filesystem::path &file_path, int line_nr, int line_count) {
-  Debug::get().remove_breakpoint(file_path, line_nr, line_count);
+  DebugClang::get().remove_breakpoint(file_path, line_nr, line_count);
 }
 
 void Project::Clang::debug_delete() {
   debug_start_mutex.lock();
-  Debug::get().delete_debug();
+  DebugClang::get().delete_debug();
   debug_start_mutex.unlock();
 }
 #endif

--- a/src/project.cc
+++ b/src/project.cc
@@ -286,7 +286,6 @@ void Project::Clang::debug_start() {
           
           debug_update_stop();
         });
-        
       });
       debug_start_mutex.unlock();
     }

--- a/src/project.cc
+++ b/src/project.cc
@@ -413,7 +413,7 @@ void ProjectMarkdown::compile_and_run() {
         Terminal::get().process("open \""+uri+"\"");
 #else
         GError* error=NULL;
-        gtk_show_uri(NULL, uri.c_str(), GDK_CURRENT_TIME, &error);
+        gtk_show_uri(NULL, ("file://"+uri).c_str(), GDK_CURRENT_TIME, &error);
         g_clear_error(&error);
 #endif
       }
@@ -443,7 +443,7 @@ void ProjectHTML::compile_and_run() {
   Terminal::get().process("open \""+uri+"\"");
 #else
   GError* error=NULL;
-  gtk_show_uri(NULL, uri.c_str(), GDK_CURRENT_TIME, &error);
+  gtk_show_uri(NULL, ("file://"+uri).c_str(), GDK_CURRENT_TIME, &error);
   g_clear_error(&error);
 #endif
 }

--- a/src/project.cc
+++ b/src/project.cc
@@ -412,8 +412,11 @@ void ProjectMarkdown::compile_and_run() {
 #ifdef __APPLE__
         Terminal::get().process("open \""+uri+"\"");
 #else
+#ifdef __linux
+        uri="file://"+uri;
+#endif
         GError* error=NULL;
-        gtk_show_uri(NULL, ("file://"+uri).c_str(), GDK_CURRENT_TIME, &error);
+        gtk_show_uri(NULL, uri.c_str(), GDK_CURRENT_TIME, &error);
         g_clear_error(&error);
 #endif
       }
@@ -442,8 +445,11 @@ void ProjectHTML::compile_and_run() {
 #ifdef __APPLE__
   Terminal::get().process("open \""+uri+"\"");
 #else
+#ifdef __linux
+  uri="file://"+uri;
+#endif
   GError* error=NULL;
-  gtk_show_uri(NULL, ("file://"+uri).c_str(), GDK_CURRENT_TIME, &error);
+  gtk_show_uri(NULL, uri.c_str(), GDK_CURRENT_TIME, &error);
   g_clear_error(&error);
 #endif
 }

--- a/src/project.cc
+++ b/src/project.cc
@@ -275,11 +275,11 @@ void Project::Clang::debug_start() {
         debugging=false;
         Terminal::get().async_print(run_arguments+" returned: "+std::to_string(exit_status)+'\n');
       }, [this](const std::string &status) {
-        dispatcher.add([this, status] {
+        dispatcher.push([this, status] {
           debug_update_status(status);
         });
       }, [this](const boost::filesystem::path &file_path, int line_nr, int line_index) {
-        dispatcher.add([this, file_path, line_nr, line_index] {
+        dispatcher.push([this, file_path, line_nr, line_index] {
           Project::debug_stop.first=file_path;
           Project::debug_stop.second.first=line_nr;
           Project::debug_stop.second.second=line_index;

--- a/src/project.cc
+++ b/src/project.cc
@@ -381,14 +381,14 @@ void ProjectClang::debug_delete() {
 }
 #endif
 
-ProjectMarkDown::~ProjectMarkDown() {
+ProjectMarkdown::~ProjectMarkdown() {
   if(!last_temp_path.empty()) {
     boost::filesystem::remove(last_temp_path);
     last_temp_path=boost::filesystem::path();
   }
 }
 
-void ProjectMarkDown::compile_and_run() {
+void ProjectMarkdown::compile_and_run() {
   if(!last_temp_path.empty()) {
     boost::filesystem::remove(last_temp_path);
     last_temp_path=boost::filesystem::path();
@@ -411,4 +411,20 @@ void ProjectMarkDown::compile_and_run() {
       }
     }
   }
+}
+
+void ProjectPython::compile_and_run() {
+  auto command="python "+notebook.get_current_view()->file_path.string();
+  Terminal::get().print("Running "+command+"\n");
+  Terminal::get().async_process(command, notebook.get_current_view()->file_path.parent_path(), [command](int exit_status) {
+    Terminal::get().async_print(command+" returned: "+std::to_string(exit_status)+'\n');
+  });
+}
+
+void ProjectJavaScript::compile_and_run() {
+  auto command="node "+notebook.get_current_view()->file_path.string();
+  Terminal::get().print("Running "+command+"\n");
+  Terminal::get().async_process(command, notebook.get_current_view()->file_path.parent_path(), [command](int exit_status) {
+    Terminal::get().async_print(command+" returned: "+std::to_string(exit_status)+'\n');
+  });
 }

--- a/src/project.cc
+++ b/src/project.cc
@@ -15,11 +15,10 @@ std::atomic<bool> Project::compiling;
 std::atomic<bool> Project::debugging;
 std::pair<boost::filesystem::path, std::pair<int, int> > Project::debug_stop;
 boost::filesystem::path Project::debug_last_stop_file_path;
-std::unique_ptr<Gtk::Label> Project::debug_status_label;
 
 void Project::debug_update_status(const std::string &debug_status) {
   if(debug_status.empty()) {
-    debug_status_label->set_text("");
+    debug_status_label().set_text("");
     auto &menu=Menu::get();
     menu.actions["debug_stop"]->set_enabled(false);
     menu.actions["debug_kill"]->set_enabled(false);
@@ -32,7 +31,7 @@ void Project::debug_update_status(const std::string &debug_status) {
     menu.actions["debug_goto_stop"]->set_enabled(false);
   }
   else {
-    debug_status_label->set_text("debug: "+debug_status);
+    debug_status_label().set_text("debug: "+debug_status);
     auto &menu=Menu::get();
     menu.actions["debug_stop"]->set_enabled();
     menu.actions["debug_kill"]->set_enabled();
@@ -279,7 +278,7 @@ void Project::Clang::debug_start() {
         dispatcher.add([this, status] {
           debug_update_status(status);
         });
-      }, [this](const boost::filesystem::path &file_path, int line_nr, int line_index) {        
+      }, [this](const boost::filesystem::path &file_path, int line_nr, int line_index) {
         dispatcher.add([this, file_path, line_nr, line_index] {
           Project::debug_stop.first=file_path;
           Project::debug_stop.second.first=line_nr;

--- a/src/project.cc
+++ b/src/project.cc
@@ -1,0 +1,113 @@
+#include "project.h"
+#include "config.h"
+#include "terminal.h"
+#include "filesystem.h"
+
+std::unordered_map<std::string, std::string> Project::run_arguments;
+std::unordered_map<std::string, std::string> Project::debug_run_arguments;
+std::atomic<bool> Project::compiling(false);
+std::atomic<bool> Project::debugging(false);
+
+std::unique_ptr<CMake> ProjectClang::get_cmake() {
+  boost::filesystem::path path;
+  if(!file_path.empty())
+    path=file_path.parent_path();
+  else
+    path=Directories::get().current_path;
+  if(path.empty())
+    return nullptr;
+  auto cmake=std::unique_ptr<CMake>(new CMake(path));
+  if(cmake->project_path.empty())
+    return nullptr;
+  if(!CMake::create_default_build(cmake->project_path))
+    return nullptr;
+  return cmake;
+}
+
+std::pair<std::string, std::string> ProjectClang::get_run_arguments() {
+  auto cmake=get_cmake();
+  if(!cmake)
+    return {"", ""};
+  
+  auto project_path=cmake->project_path.string();
+  auto run_arguments_it=run_arguments.find(project_path);
+  std::string arguments;
+  if(run_arguments_it!=run_arguments.end())
+    arguments=run_arguments_it->second;
+  
+  if(arguments.empty()) {
+    auto executable=cmake->get_executable(file_path).string();
+    
+    if(executable!="") {
+      auto project_path=cmake->project_path;
+      auto default_build_path=CMake::get_default_build_path(project_path);
+      if(!default_build_path.empty()) {
+        size_t pos=executable.find(project_path.string());
+        if(pos!=std::string::npos)
+          executable.replace(pos, project_path.string().size(), default_build_path.string());
+      }
+      arguments=filesystem::escape_argument(executable);
+    }
+    else
+      arguments=filesystem::escape_argument(CMake::get_default_build_path(cmake->project_path));
+  }
+  
+  return {project_path, arguments};
+}
+
+void ProjectClang::compile() {    
+  auto cmake=get_cmake();
+  if(!cmake)
+    return;
+  
+  auto default_build_path=CMake::get_default_build_path(cmake->project_path);
+  if(default_build_path.empty())
+    return;
+  compiling=true;
+  Terminal::get().print("Compiling project "+cmake->project_path.string()+"\n");
+  Terminal::get().async_process(Config::get().terminal.make_command, default_build_path, [this](int exit_status) {
+    compiling=false;
+  });
+}
+
+void ProjectClang::compile_and_run() {
+  auto cmake=get_cmake();
+  if(!cmake)
+    return;
+  auto project_path=cmake->project_path;
+  
+  auto default_build_path=CMake::get_default_build_path(project_path);
+  if(default_build_path.empty())
+    return;
+  
+  auto run_arguments_it=run_arguments.find(project_path.string());
+  std::string arguments;
+  if(run_arguments_it!=run_arguments.end())
+    arguments=run_arguments_it->second;
+  
+  if(arguments.empty()) {
+    arguments=cmake->get_executable(file_path).string();
+    if(arguments.empty()) {
+      Terminal::get().print("Could not find add_executable in the following paths:\n");
+      for(auto &path: cmake->paths)
+        Terminal::get().print("  "+path.string()+"\n");
+      Terminal::get().print("Solution: either use Project Set Run Arguments, or open a source file within a directory where add_executable is set.\n", true);
+      return;
+    }
+    size_t pos=arguments.find(project_path.string());
+    if(pos!=std::string::npos)
+      arguments.replace(pos, project_path.string().size(), default_build_path.string());
+    arguments=filesystem::escape_argument(arguments);
+  }
+  
+  compiling=true;
+  Terminal::get().print("Compiling and running "+arguments+"\n");
+  Terminal::get().async_process(Config::get().terminal.make_command, default_build_path, [this, arguments, default_build_path](int exit_status){
+    compiling=false;
+    if(exit_status==EXIT_SUCCESS) {
+      Terminal::get().async_process(arguments, default_build_path, [this, arguments](int exit_status){
+        Terminal::get().async_print(arguments+" returned: "+std::to_string(exit_status)+'\n');
+      });
+    }
+  });
+}

--- a/src/project.cc
+++ b/src/project.cc
@@ -19,32 +19,20 @@ boost::filesystem::path Project::debug_last_stop_file_path;
 std::unique_ptr<Project::Language> Project::current_language;
 
 void Project::debug_update_status(const std::string &debug_status) {
-  if(debug_status.empty()) {
+  if(debug_status.empty())
     debug_status_label().set_text("");
-    auto &menu=Menu::get();
-    menu.actions["debug_stop"]->set_enabled(false);
-    menu.actions["debug_kill"]->set_enabled(false);
-    menu.actions["debug_step_over"]->set_enabled(false);
-    menu.actions["debug_step_into"]->set_enabled(false);
-    menu.actions["debug_step_out"]->set_enabled(false);
-    menu.actions["debug_backtrace"]->set_enabled(false);
-    menu.actions["debug_show_variables"]->set_enabled(false);
-    menu.actions["debug_run_command"]->set_enabled(false);
-    menu.actions["debug_goto_stop"]->set_enabled(false);
-  }
-  else {
+  else
     debug_status_label().set_text("debug: "+debug_status);
-    auto &menu=Menu::get();
-    menu.actions["debug_stop"]->set_enabled();
-    menu.actions["debug_kill"]->set_enabled();
-    menu.actions["debug_step_over"]->set_enabled();
-    menu.actions["debug_step_into"]->set_enabled();
-    menu.actions["debug_step_out"]->set_enabled();
-    menu.actions["debug_backtrace"]->set_enabled();
-    menu.actions["debug_show_variables"]->set_enabled();
-    menu.actions["debug_run_command"]->set_enabled();
-    menu.actions["debug_goto_stop"]->set_enabled();
-  }
+  auto &menu=Menu::get();
+  menu.actions["debug_stop"]->set_enabled(!debug_status.empty());
+  menu.actions["debug_kill"]->set_enabled(!debug_status.empty());
+  menu.actions["debug_step_over"]->set_enabled(!debug_status.empty());
+  menu.actions["debug_step_into"]->set_enabled(!debug_status.empty());
+  menu.actions["debug_step_out"]->set_enabled(!debug_status.empty());
+  menu.actions["debug_backtrace"]->set_enabled(!debug_status.empty());
+  menu.actions["debug_show_variables"]->set_enabled(!debug_status.empty());
+  menu.actions["debug_run_command"]->set_enabled(!debug_status.empty());
+  menu.actions["debug_goto_stop"]->set_enabled(!debug_status.empty());
 }
 
 void Project::debug_update_stop() {

--- a/src/project.h
+++ b/src/project.h
@@ -1,6 +1,7 @@
 #ifndef JUCI_PROJECT_H_
 #define JUCI_PROJECT_H_
 
+#include <gtkmm.h>
 #include "notebook.h"
 #include "cmake.h"
 #include <boost/filesystem.hpp>
@@ -10,93 +11,115 @@
 #include "tooltips.h"
 
 class Project {
-public:
-  Project(Notebook &notebook) : notebook(notebook) {}
-  virtual ~Project() {}
-  
-  Notebook &notebook;
-  
-  static std::unordered_map<std::string, std::string> run_arguments;
-  static std::unordered_map<std::string, std::string> debug_run_arguments;
-  static std::atomic<bool> compiling;
-  static std::atomic<bool> debugging;
-  
-  virtual std::pair<std::string, std::string> get_run_arguments() {return {"", ""};}
-  virtual void compile() {}
-  virtual void compile_and_run() {}
-  
-  virtual std::pair<std::string, std::string> debug_get_run_arguments() {return {"", ""};}
-  Tooltips debug_variable_tooltips;
-  virtual void debug_start(std::function<void(const std::string &status)> status_callback,
-                           std::function<void(const boost::filesystem::path &file_path, int line_nr, int line_index)> stop_callback) {}
-  virtual void debug_continue() {}
-  virtual void debug_stop() {}
-  virtual void debug_kill() {}
-  virtual void debug_step_over() {}
-  virtual void debug_step_into() {}
-  virtual void debug_step_out() {}
-  virtual void debug_backtrace() {}
-  virtual void debug_show_variables() {}
-  virtual void debug_run_command(const std::string &command) {}
-  virtual void debug_delete() {}
-};
+private:
+  std::pair<boost::filesystem::path, std::pair<int, int> > debug_stop;
+  std::mutex debug_stop_mutex;
+  boost::filesystem::path debug_last_stop_file_path;
+  Glib::Dispatcher debug_update_stop;
+  std::string debug_status;
+  std::mutex debug_status_mutex;
+  Glib::Dispatcher debug_update_status;
 
-class ProjectClang : public Project {
+  Project();
+  Notebook &notebook; //convenience reference
 public:
-  ProjectClang(Notebook &notebook) : Project(notebook) {}
-  
-  std::unique_ptr<CMake> get_cmake();
-  
-  std::pair<std::string, std::string> get_run_arguments() override;
-  void compile() override;
-  void compile_and_run() override;
-  
-  std::mutex debug_start_mutex;
-#ifdef JUCI_ENABLE_DEBUG
-  std::pair<std::string, std::string> debug_get_run_arguments() override;
-  void debug_start(std::function<void(const std::string &status)> status_callback,
-                   std::function<void(const boost::filesystem::path &file_path, int line_nr, int line_index)> stop_callback) override;
-  void debug_continue() override;
-  void debug_stop() override;
-  void debug_kill() override;
-  void debug_step_over() override;
-  void debug_step_into() override;
-  void debug_step_out() override;
-  void debug_backtrace() override;
-  void debug_show_variables() override;
-  void debug_run_command(const std::string &command) override;
-  void debug_delete() override;
-#endif
-};
+  static Project &get() {
+    static Project singleton;
+    return singleton;
+  }
 
-class ProjectMarkdown : public Project {
-public:
-  ProjectMarkdown(Notebook &notebook) : Project(notebook) {}
-  ~ProjectMarkdown();
+  Gtk::Label debug_status_label;
+  std::unordered_map<std::string, std::string> run_arguments;
+  std::unordered_map<std::string, std::string> debug_run_arguments;
+  std::atomic<bool> compiling;
+  std::atomic<bool> debugging;
   
-  boost::filesystem::path last_temp_path;
-  void compile_and_run() override;
-};
-
-class ProjectPython : public Project {
-public:
-  ProjectPython(Notebook &notebook) : Project(notebook) {}
+  class Language {
+  protected:
+    Notebook &notebook; //convenience reference
+  public:
+    Language() : notebook(Notebook::get()) {}
+    virtual ~Language() {}
+    
+    virtual std::pair<std::string, std::string> get_run_arguments() {return {"", ""};}
+    virtual void compile() {}
+    virtual void compile_and_run() {}
+    
+    virtual std::pair<std::string, std::string> debug_get_run_arguments() {return {"", ""};}
+    Tooltips debug_variable_tooltips;
+    virtual void debug_start() {}
+    virtual void debug_continue() {}
+    virtual void debug_stop() {}
+    virtual void debug_kill() {}
+    virtual void debug_step_over() {}
+    virtual void debug_step_into() {}
+    virtual void debug_step_out() {}
+    virtual void debug_backtrace() {}
+    virtual void debug_show_variables() {}
+    virtual void debug_run_command(const std::string &command) {}
+    virtual void debug_goto_stop() {}
+    virtual void debug_delete() {}
+  };
   
-  void compile_and_run() override;
-};
-
-class ProjectJavaScript : public Project {
-public:
-  ProjectJavaScript(Notebook &notebook) : Project(notebook) {}
+  class Clang : public Language {
+  public:
+    Clang() : Language() {}
+    
+    std::unique_ptr<CMake> get_cmake();
+    
+    std::pair<std::string, std::string> get_run_arguments() override;
+    void compile() override;
+    void compile_and_run() override;
+    
+    std::mutex debug_start_mutex;
+  #ifdef JUCI_ENABLE_DEBUG
+    std::pair<std::string, std::string> debug_get_run_arguments() override;
+    void debug_start() override;
+    void debug_continue() override;
+    void debug_stop() override;
+    void debug_kill() override;
+    void debug_step_over() override;
+    void debug_step_into() override;
+    void debug_step_out() override;
+    void debug_backtrace() override;
+    void debug_show_variables() override;
+    void debug_run_command(const std::string &command) override;
+    void debug_goto_stop() override;
+    void debug_delete() override;
+  #endif
+  };
   
-  void compile_and_run() override;
-};
-
-class ProjectHTML : public Project {
-public:
-  ProjectHTML(Notebook &notebook) : Project(notebook) {}
+  class Markdown : public Language {
+  public:
+    Markdown() : Language() {}
+    ~Markdown();
+    
+    boost::filesystem::path last_temp_path;
+    void compile_and_run() override;
+  };
   
-  void compile_and_run() override;
+  class Python : public Language {
+  public:
+    Python() : Language() {}
+    
+    void compile_and_run() override;
+  };
+  
+  class JavaScript : public Language {
+  public:
+    JavaScript() : Language() {}
+    
+    void compile_and_run() override;
+  };
+  
+  class HTML : public Language {
+  public:
+    HTML() : Language() {}
+    
+    void compile_and_run() override;
+  };
+  
+  std::unique_ptr<Language> get_language();
 };
 
 #endif  // JUCI_PROJECT_H_

--- a/src/project.h
+++ b/src/project.h
@@ -57,6 +57,7 @@ public:
     virtual void debug_backtrace() {}
     virtual void debug_show_variables() {}
     virtual void debug_run_command(const std::string &command) {}
+    virtual void toggle_breakpoint() {}
     virtual void debug_goto_stop() {}
     virtual void debug_delete() {}
   };
@@ -84,6 +85,7 @@ public:
     void debug_backtrace() override;
     void debug_show_variables() override;
     void debug_run_command(const std::string &command) override;
+    void toggle_breakpoint() override;
     void debug_goto_stop() override;
     void debug_delete() override;
   #endif

--- a/src/project.h
+++ b/src/project.h
@@ -21,8 +21,12 @@ public:
   static std::atomic<bool> debugging;
   static std::pair<boost::filesystem::path, std::pair<int, int> > debug_stop;
   static void debug_update_stop();
-  static std::unique_ptr<Gtk::Label> debug_status_label;
   static void debug_update_status(const std::string &debug_status);
+  
+  static Gtk::Label &debug_status_label() {
+    static Gtk::Label label;
+    return label;
+  }
   
   class Language {
   public:

--- a/src/project.h
+++ b/src/project.h
@@ -51,6 +51,8 @@ public:
     virtual void debug_run_command(const std::string &command) {}
     virtual void debug_add_breakpoint(const boost::filesystem::path &file_path, int line_nr) {}
     virtual void debug_remove_breakpoint(const boost::filesystem::path &file_path, int line_nr, int line_count) {}
+    virtual bool debug_is_running() { return false; }
+    virtual void debug_write(const std::string &buffer) {}
     virtual void debug_delete() {}
   };
   
@@ -82,6 +84,8 @@ public:
     void debug_run_command(const std::string &command) override;
     void debug_add_breakpoint(const boost::filesystem::path &file_path, int line_nr) override;
     void debug_remove_breakpoint(const boost::filesystem::path &file_path, int line_nr, int line_count) override;
+    bool debug_is_running() override;
+    void debug_write(const std::string &buffer) override;
     void debug_delete() override;
   #endif
   };
@@ -117,6 +121,7 @@ public:
   };
   
   static std::unique_ptr<Language> get_language();
+  static std::unique_ptr<Language> current_language;
 };
 
 #endif  // JUCI_PROJECT_H_

--- a/src/project.h
+++ b/src/project.h
@@ -69,12 +69,26 @@ public:
   void debug_delete() override;
 };
 
-class ProjectMarkDown : public Project {
+class ProjectMarkdown : public Project {
 public:
-  ProjectMarkDown(Notebook &notebook) : Project(notebook) {}
-  ~ProjectMarkDown();
+  ProjectMarkdown(Notebook &notebook) : Project(notebook) {}
+  ~ProjectMarkdown();
   
   boost::filesystem::path last_temp_path;
+  void compile_and_run() override;
+};
+
+class ProjectPython : public Project {
+public:
+  ProjectPython(Notebook &notebook) : Project(notebook) {}
+  
+  void compile_and_run() override;
+};
+
+class ProjectJavaScript : public Project {
+public:
+  ProjectJavaScript(Notebook &notebook) : Project(notebook) {}
+  
   void compile_and_run() override;
 };
 

--- a/src/project.h
+++ b/src/project.h
@@ -12,10 +12,7 @@
 
 class Project {
 private:
-  std::pair<boost::filesystem::path, std::pair<int, int> > debug_stop;
-  std::mutex debug_stop_mutex;
   boost::filesystem::path debug_last_stop_file_path;
-  Glib::Dispatcher debug_update_stop;
   std::string debug_status;
   std::mutex debug_status_mutex;
   Glib::Dispatcher debug_update_status;
@@ -29,6 +26,9 @@ public:
   }
 
   Gtk::Label debug_status_label;
+  std::pair<boost::filesystem::path, std::pair<int, int> > debug_stop;
+  std::mutex debug_stop_mutex;
+  Glib::Dispatcher debug_update_stop;
   std::unordered_map<std::string, std::string> run_arguments;
   std::unordered_map<std::string, std::string> debug_run_arguments;
   std::atomic<bool> compiling;
@@ -57,8 +57,8 @@ public:
     virtual void debug_backtrace() {}
     virtual void debug_show_variables() {}
     virtual void debug_run_command(const std::string &command) {}
-    virtual void toggle_breakpoint() {}
-    virtual void debug_goto_stop() {}
+    virtual void debug_add_breakpoint(const boost::filesystem::path &file_path, int line_nr) {}
+    virtual void debug_remove_breakpoint(const boost::filesystem::path &file_path, int line_nr, int line_count) {}
     virtual void debug_delete() {}
   };
   
@@ -85,8 +85,8 @@ public:
     void debug_backtrace() override;
     void debug_show_variables() override;
     void debug_run_command(const std::string &command) override;
-    void toggle_breakpoint() override;
-    void debug_goto_stop() override;
+    void debug_add_breakpoint(const boost::filesystem::path &file_path, int line_nr) override;
+    void debug_remove_breakpoint(const boost::filesystem::path &file_path, int line_nr, int line_count) override;
     void debug_delete() override;
   #endif
   };

--- a/src/project.h
+++ b/src/project.h
@@ -47,4 +47,13 @@ public:
   void compile_and_run() override;
 };
 
+class ProjectMarkDown : public Project {
+public:
+  ProjectMarkDown(const boost::filesystem::path &file_path) : Project(file_path) {}
+  ~ProjectMarkDown();
+  
+  boost::filesystem::path last_temp_path;
+  void compile_and_run() override;
+};
+
 #endif  // JUCI_PROJECT_H_

--- a/src/project.h
+++ b/src/project.h
@@ -1,0 +1,50 @@
+#ifndef JUCI_PROJECT_H_
+#define JUCI_PROJECT_H_
+
+#include "cmake.h"
+#include <boost/filesystem.hpp>
+#include "directories.h"
+#include <atomic>
+
+class Project {
+public:
+  Project(const boost::filesystem::path &file_path) : file_path(file_path) {}
+  virtual ~Project() {}
+  
+  boost::filesystem::path file_path;
+  
+  static std::unordered_map<std::string, std::string> run_arguments;
+  static std::unordered_map<std::string, std::string> debug_run_arguments;
+  static std::atomic<bool> compiling;
+  static std::atomic<bool> debugging;
+  
+  virtual std::pair<std::string, std::string> get_run_arguments() {return {"", ""};}
+  virtual void compile() {}
+  virtual void compile_and_run() {}
+  
+  virtual std::pair<std::string, std::string> debug_get_run_arguments() {return {"", ""};}
+  virtual void debug_start_continue() {}
+  virtual void debug_stop() {}
+  virtual void debug_kill() {}
+  virtual void debug_step_over() {}
+  virtual void debug_step_into() {}
+  virtual void debug_step_out() {}
+  virtual void debug_backtrace() {}
+  virtual void debug_show_variables() {}
+  virtual void debug_run_command() {}
+  virtual void debug_toggle_breakpoint() {}
+  virtual void debug_goto_stop() {}
+};
+
+class ProjectClang : public Project {
+public:
+  ProjectClang(const boost::filesystem::path &file_path) : Project(file_path) {}
+  
+  std::unique_ptr<CMake> get_cmake();
+  
+  std::pair<std::string, std::string> get_run_arguments() override;
+  void compile() override;
+  void compile_and_run() override;
+};
+
+#endif  // JUCI_PROJECT_H_

--- a/src/project.h
+++ b/src/project.h
@@ -1,15 +1,13 @@
 #ifndef JUCI_PROJECT_H_
 #define JUCI_PROJECT_H_
 
-#include "notebook.h" //Avoiding this circular include would lead to bloated code
+#include "notebook.h"
 #include "cmake.h"
 #include <boost/filesystem.hpp>
 #include "directories.h"
 #include <atomic>
 #include <mutex>
 #include "tooltips.h"
-
-class Notebook; //Avoiding this circular include would lead to bloated code
 
 class Project {
 public:

--- a/src/project.h
+++ b/src/project.h
@@ -53,8 +53,9 @@ public:
   void compile() override;
   void compile_and_run() override;
   
-  std::pair<std::string, std::string> debug_get_run_arguments() override;
   std::mutex debug_start_mutex;
+#ifdef JUCI_ENABLE_DEBUG
+  std::pair<std::string, std::string> debug_get_run_arguments() override;
   void debug_start(std::function<void(const std::string &status)> status_callback,
                    std::function<void(const boost::filesystem::path &file_path, int line_nr, int line_index)> stop_callback) override;
   void debug_continue() override;
@@ -67,6 +68,7 @@ public:
   void debug_show_variables() override;
   void debug_run_command(const std::string &command) override;
   void debug_delete() override;
+#endif
 };
 
 class ProjectMarkdown : public Project {
@@ -88,6 +90,13 @@ public:
 class ProjectJavaScript : public Project {
 public:
   ProjectJavaScript(Notebook &notebook) : Project(notebook) {}
+  
+  void compile_and_run() override;
+};
+
+class ProjectHTML : public Project {
+public:
+  ProjectHTML(Notebook &notebook) : Project(notebook) {}
   
   void compile_and_run() override;
 };

--- a/src/selectiondialog.cc
+++ b/src/selectiondialog.cc
@@ -38,10 +38,6 @@ void ListViewText::append(const std::string& value) {
   new_row->set_value(column_record.text, value);
 }
 
-void ListViewText::clear() {
-  list_store->clear();
-}
-
 SelectionDialogBase::SelectionDialogBase(Gtk::TextView& text_view, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, bool show_search_entry, bool use_markup): text_view(text_view), 
 list_view_text(use_markup), start_mark(start_mark), show_search_entry(show_search_entry) {
   if(!show_search_entry)
@@ -121,7 +117,6 @@ void SelectionDialogBase::hide() {
   window->hide();
   if(on_hide)
     on_hide();
-  list_view_text.clear();
 }
 
 void SelectionDialogBase::move() {

--- a/src/selectiondialog.h
+++ b/src/selectiondialog.h
@@ -17,7 +17,6 @@ public:
   bool use_markup;
   ListViewText(bool use_markup);
   void append(const std::string& value);
-  void clear();
 private:
   Glib::RefPtr<Gtk::ListStore> list_store;
   ColumnRecord column_record;

--- a/src/source_clang.cc
+++ b/src/source_clang.cc
@@ -200,7 +200,8 @@ std::vector<std::string> Source::ClangViewParse::get_compilation_commands() {
     arguments.emplace_back("-I/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1"); //Added for OS X 10.11
 #endif
 #ifdef _WIN32
-    arguments.emplace_back("-I"+(Config::get().terminal.msys2_mingw_path/"lib/clang"/clang_version/"include").string());
+    if(!Config::get().terminal.msys2_mingw_path.empty())
+      arguments.emplace_back("-I"+(Config::get().terminal.msys2_mingw_path/"lib/clang"/clang_version/"include").string());
 #endif
   }
   arguments.emplace_back("-fretain-comments-from-system-headers");

--- a/src/source_clang.cc
+++ b/src/source_clang.cc
@@ -875,7 +875,7 @@ void Source::ClangViewAutocomplete::autocomplete() {
       parse_process_state=ParseProcessState::IDLE;
       auto autocomplete_data=std::make_shared<std::vector<AutoCompleteData> >(autocomplete_get_suggestions(buffer->raw(), line_nr, column_nr));
       
-      if(parse_state==ParseState::PROCESSING)
+      if(parse_state==ParseState::PROCESSING) {
         dispatcher.add([this, autocomplete_data] {
           if(autocomplete_state==AutocompleteState::CANCELED) {
             set_status("");
@@ -911,6 +911,7 @@ void Source::ClangViewAutocomplete::autocomplete() {
                 autocomplete_dialog->add_row(row);
               }
             }
+            autocomplete_data->clear();
             set_status("");
             autocomplete_state=AutocompleteState::IDLE;
             if (!autocomplete_dialog_rows.empty()) {
@@ -921,6 +922,7 @@ void Source::ClangViewAutocomplete::autocomplete() {
               soft_reparse();
           }
         });
+      }
       else {
         dispatcher.add([this] {
           Terminal::get().print("Error: autocomplete failed, reparsing "+this->file_path.string()+"\n", true);

--- a/src/source_clang.cc
+++ b/src/source_clang.cc
@@ -3,7 +3,7 @@
 #include "terminal.h"
 #include "cmake.h"
 #ifdef JUCI_ENABLE_DEBUG
-#include "debug.h"
+#include "debug_clang.h"
 #endif
 
 namespace sigc {
@@ -414,15 +414,15 @@ void Source::ClangViewParse::show_type_tooltips(const Gdk::Rectangle &rectangle)
               tooltip_buffer->insert_with_tag(tooltip_buffer->get_insert()->get_iter(), "\n\n"+brief_comment, "def:note");
 
 #ifdef JUCI_ENABLE_DEBUG
-            if(Debug::get().is_stopped()) {
+            if(DebugClang::get().is_stopped()) {
               auto location=token.get_cursor().get_referenced().get_source_location();
               Glib::ustring value_type="Value";
-              Glib::ustring debug_value=Debug::get().get_value(token.get_spelling(), location.get_path(), location.get_offset().line, location.get_offset().index);
+              Glib::ustring debug_value=DebugClang::get().get_value(token.get_spelling(), location.get_path(), location.get_offset().line, location.get_offset().index);
               if(debug_value.empty()) {
                 value_type="Return value";
                 auto cursor=token.get_cursor();
                 auto offsets=cursor.get_source_range().get_offsets();
-                debug_value=Debug::get().get_return_value(cursor.get_source_location().get_path(), offsets.first.line, offsets.first.index);
+                debug_value=DebugClang::get().get_return_value(cursor.get_source_location().get_path(), offsets.first.line, offsets.first.index);
               }
               if(!debug_value.empty()) {
                 size_t pos=debug_value.find(" = ");

--- a/src/source_clang.cc
+++ b/src/source_clang.cc
@@ -414,15 +414,15 @@ void Source::ClangViewParse::show_type_tooltips(const Gdk::Rectangle &rectangle)
               tooltip_buffer->insert_with_tag(tooltip_buffer->get_insert()->get_iter(), "\n\n"+brief_comment, "def:note");
 
 #ifdef JUCI_ENABLE_DEBUG
-            if(DebugClang::get().is_stopped()) {
+            if(Debug::Clang::get().is_stopped()) {
               auto location=token.get_cursor().get_referenced().get_source_location();
               Glib::ustring value_type="Value";
-              Glib::ustring debug_value=DebugClang::get().get_value(token.get_spelling(), location.get_path(), location.get_offset().line, location.get_offset().index);
+              Glib::ustring debug_value=Debug::Clang::get().get_value(token.get_spelling(), location.get_path(), location.get_offset().line, location.get_offset().index);
               if(debug_value.empty()) {
                 value_type="Return value";
                 auto cursor=token.get_cursor();
                 auto offsets=cursor.get_source_range().get_offsets();
-                debug_value=DebugClang::get().get_return_value(cursor.get_source_location().get_path(), offsets.first.line, offsets.first.index);
+                debug_value=Debug::Clang::get().get_return_value(cursor.get_source_location().get_path(), offsets.first.line, offsets.first.index);
               }
               if(!debug_value.empty()) {
                 size_t pos=debug_value.find(" = ");

--- a/src/source_clang.cc
+++ b/src/source_clang.cc
@@ -886,9 +886,7 @@ void Source::ClangViewAutocomplete::autocomplete() {
             set_status("");
             soft_reparse();
             autocomplete_state=AutocompleteState::IDLE;
-            dispatcher.add([this] {
-              autocomplete_check();
-            });
+            autocomplete_check();
           }
           else {
             autocomplete_dialog_setup();

--- a/src/source_clang.cc
+++ b/src/source_clang.cc
@@ -200,10 +200,7 @@ std::vector<std::string> Source::ClangViewParse::get_compilation_commands() {
     arguments.emplace_back("-I/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1"); //Added for OS X 10.11
 #endif
 #ifdef _WIN32
-    arguments.emplace_back("-IC:/msys32/mingw32/lib/clang/"+clang_version+"/include");
-    arguments.emplace_back("-IC:/msys32/mingw64/lib/clang/"+clang_version+"/include");
-    arguments.emplace_back("-IC:/msys64/mingw32/lib/clang/"+clang_version+"/include");
-    arguments.emplace_back("-IC:/msys64/mingw64/lib/clang/"+clang_version+"/include");
+    arguments.emplace_back("-I"+(Config::get().terminal.msys2_mingw_path/"lib/clang"/clang_version/"include").string());
 #endif
   }
   arguments.emplace_back("-fretain-comments-from-system-headers");

--- a/src/source_clang.cc
+++ b/src/source_clang.cc
@@ -35,36 +35,6 @@ Source::View(file_path, project_path, language) {
   configure();
   
   parsing_in_progress=Terminal::get().print_in_progress("Parsing "+file_path.string());
-  //GTK-calls must happen in main thread, so the parse_thread
-  //sends signals to the main thread that it is to call the following functions:
-  parse_preprocess_connection=parse_preprocess.connect([this]{
-    auto expected=ParseProcessState::PREPROCESSING;
-    if(parse_mutex.try_lock()) {
-      if(parse_process_state.compare_exchange_strong(expected, ParseProcessState::PROCESSING))
-        parse_thread_buffer=get_buffer()->get_text();
-      parse_mutex.unlock();
-    }
-    else
-      parse_process_state.compare_exchange_strong(expected, ParseProcessState::STARTING);
-  });
-  parse_postprocess_connection=parse_postprocess.connect([this](){
-    if(parse_mutex.try_lock()) {
-      auto expected=ParseProcessState::POSTPROCESSING;
-      if(parse_process_state.compare_exchange_strong(expected, ParseProcessState::IDLE)) {
-        update_syntax();
-        update_diagnostics();
-        parsed=true;
-        set_status("");
-      }
-      parse_mutex.unlock();
-    }
-  });
-  parse_error_connection=parse_error.connect([this](){
-    Terminal::get().print("Error: failed to reparse "+this->file_path.string()+".\n", true);
-    set_status("");
-    set_info("");
-    parsing_in_progress->cancel("failed");
-  });
   parse_initialize();
   
   get_buffer()->signal_changed().connect([this]() {
@@ -140,8 +110,18 @@ void Source::ClangViewParse::parse_initialize() {
       if(parse_state!=ParseState::PROCESSING)
         break;
       auto expected=ParseProcessState::STARTING;
-      if(parse_process_state.compare_exchange_strong(expected, ParseProcessState::PREPROCESSING))
-        parse_preprocess();
+      if(parse_process_state.compare_exchange_strong(expected, ParseProcessState::PREPROCESSING)) {
+        dispatcher.add([this] {
+          auto expected=ParseProcessState::PREPROCESSING;
+          if(parse_mutex.try_lock()) {
+            if(parse_process_state.compare_exchange_strong(expected, ParseProcessState::PROCESSING))
+              parse_thread_buffer=get_buffer()->get_text();
+            parse_mutex.unlock();
+          }
+          else
+            parse_process_state.compare_exchange_strong(expected, ParseProcessState::STARTING);
+        });
+      }
       else if (parse_process_state==ParseProcessState::PROCESSING && parse_mutex.try_lock()) {
         auto status=clang_tu->ReparseTranslationUnit(parse_thread_buffer.raw());
         parsing_in_progress->done("done");
@@ -150,7 +130,18 @@ void Source::ClangViewParse::parse_initialize() {
           if(parse_process_state.compare_exchange_strong(expected, ParseProcessState::POSTPROCESSING)) {
             clang_tokens=clang_tu->get_tokens(0, parse_thread_buffer.bytes()-1);
             parse_mutex.unlock();
-            parse_postprocess();
+            dispatcher.add([this] {
+              if(parse_mutex.try_lock()) {
+                auto expected=ParseProcessState::POSTPROCESSING;
+                if(parse_process_state.compare_exchange_strong(expected, ParseProcessState::IDLE)) {
+                  update_syntax();
+                  update_diagnostics();
+                  parsed=true;
+                  set_status("");
+                }
+                parse_mutex.unlock();
+              }
+            });
           }
           else
             parse_mutex.unlock();
@@ -158,7 +149,12 @@ void Source::ClangViewParse::parse_initialize() {
         else {
           parse_state=ParseState::STOP;
           parse_mutex.unlock();
-          parse_error();
+          dispatcher.add([this] {
+            Terminal::get().print("Error: failed to reparse "+this->file_path.string()+".\n", true);
+            set_status("");
+            set_info("");
+            parsing_in_progress->cancel("failed");
+          });
         }
       }
     }
@@ -713,69 +709,10 @@ Source::ClangViewParse(file_path, project_path, language), autocomplete_state(Au
     return false;
   });
   
-  autocomplete_done_connection=autocomplete_done.connect([this](){
-    if(autocomplete_state==AutocompleteState::CANCELED) {
-      set_status("");
-      soft_reparse();
-      autocomplete_state=AutocompleteState::IDLE;
-    }
-    else if(autocomplete_state==AutocompleteState::RESTARTING) {
-      set_status("");
-      soft_reparse();
-      autocomplete_state=AutocompleteState::IDLE;
-      autocomplete_restart();
-    }
-    else {
-      autocomplete_dialog_setup();
-      
-      for (auto &data : autocomplete_data) {
-        std::string row;
-        std::string return_value;
-        for (auto &chunk : data.chunks) {
-          if(chunk.kind==clang::CompletionChunk_ResultType)
-            return_value=chunk.chunk;
-          else if(chunk.kind!=clang::CompletionChunk_Informative)
-            row+=chunk.chunk;
-        }
-        data.chunks.clear();
-        if (!row.empty()) {
-          auto row_insert_on_selection=row;
-          if(!return_value.empty())
-            row+=" --> " + return_value;
-          autocomplete_dialog_rows[row] = std::pair<std::string, std::string>(std::move(row_insert_on_selection), std::move(data.brief_comments));
-          autocomplete_dialog->add_row(row);
-        }
-      }
-      autocomplete_data.clear();
-      set_status("");
-      autocomplete_state=AutocompleteState::IDLE;
-      if (!autocomplete_dialog_rows.empty()) {
-        get_source_buffer()->begin_user_action();
-        autocomplete_dialog->show();
-      }
-      else
-        soft_reparse();
-    }
-  });
-  
-  autocomplete_restart_connection=autocomplete_restart.connect([this]() {
-    autocomplete_check();
-  });
-  autocomplete_error_connection=autocomplete_error.connect([this]() {
-    Terminal::get().print("Error: autocomplete failed, reparsing "+this->file_path.string()+"\n", true);
-    autocomplete_state=AutocompleteState::CANCELED;
-    full_reparse();
-  });
-  
-  do_delete_object_connection=do_delete_object.connect([this](){
+  do_delete_object.connect([this](){
     if(delete_thread.joinable())
       delete_thread.join();
-    do_delete_object_connection.disconnect();
     delete this;
-  });
-  do_full_reparse.connect([this](){
-    parse_initialize();
-    full_reparse_running=false;
   });
 }
 
@@ -847,7 +784,7 @@ void Source::ClangViewAutocomplete::autocomplete_dialog_setup() {
         //new autocomplete after for instance when selecting "std::"
         auto iter=get_buffer()->get_insert()->get_iter();
         if(iter.backward_char() && *iter==':')
-          autocomplete_restart();
+          autocomplete_check();
       }
     }
   };
@@ -918,8 +855,6 @@ void Source::ClangViewAutocomplete::autocomplete() {
 
   autocomplete_state=AutocompleteState::STARTING;
   
-  autocomplete_data.clear();
-  
   set_status("autocomplete...");
   if(autocomplete_thread.joinable())
     autocomplete_thread.join();
@@ -938,12 +873,62 @@ void Source::ClangViewAutocomplete::autocomplete() {
     parse_mutex.lock();
     if(parse_state==ParseState::PROCESSING) {
       parse_process_state=ParseProcessState::IDLE;
-      autocomplete_data=autocomplete_get_suggestions(buffer->raw(), line_nr, column_nr);
+      auto autocomplete_data=std::make_shared<std::vector<AutoCompleteData> >(autocomplete_get_suggestions(buffer->raw(), line_nr, column_nr));
+      
+      if(parse_state==ParseState::PROCESSING)
+        dispatcher.add([this, autocomplete_data] {
+          if(autocomplete_state==AutocompleteState::CANCELED) {
+            set_status("");
+            soft_reparse();
+            autocomplete_state=AutocompleteState::IDLE;
+          }
+          else if(autocomplete_state==AutocompleteState::RESTARTING) {
+            set_status("");
+            soft_reparse();
+            autocomplete_state=AutocompleteState::IDLE;
+            dispatcher.add([this] {
+              autocomplete_check();
+            });
+          }
+          else {
+            autocomplete_dialog_setup();
+            
+            for (auto &data : *autocomplete_data) {
+              std::string row;
+              std::string return_value;
+              for (auto &chunk : data.chunks) {
+                if(chunk.kind==clang::CompletionChunk_ResultType)
+                  return_value=chunk.chunk;
+                else if(chunk.kind!=clang::CompletionChunk_Informative)
+                  row+=chunk.chunk;
+              }
+              data.chunks.clear();
+              if (!row.empty()) {
+                auto row_insert_on_selection=row;
+                if(!return_value.empty())
+                  row+=" --> " + return_value;
+                autocomplete_dialog_rows[row] = std::pair<std::string, std::string>(std::move(row_insert_on_selection), std::move(data.brief_comments));
+                autocomplete_dialog->add_row(row);
+              }
+            }
+            set_status("");
+            autocomplete_state=AutocompleteState::IDLE;
+            if (!autocomplete_dialog_rows.empty()) {
+              get_source_buffer()->begin_user_action();
+              autocomplete_dialog->show();
+            }
+            else
+              soft_reparse();
+          }
+        });
+      else {
+        dispatcher.add([this] {
+          Terminal::get().print("Error: autocomplete failed, reparsing "+this->file_path.string()+"\n", true);
+          autocomplete_state=AutocompleteState::CANCELED;
+          full_reparse();
+        });
+      }
     }
-    if(parse_state==ParseState::PROCESSING)
-      autocomplete_done();
-    else
-      autocomplete_error();
     parse_mutex.unlock();
   });
 }
@@ -1017,7 +1002,10 @@ bool Source::ClangViewAutocomplete::full_reparse() {
         parse_thread.join();
       if(autocomplete_thread.joinable())
         autocomplete_thread.join();
-      do_full_reparse();
+      dispatcher.add([this] {
+        parse_initialize();
+        full_reparse_running=false;
+      });
     });
     return true;
   }
@@ -1479,14 +1467,8 @@ Source::ClangView::ClangView(const boost::filesystem::path &file_path, const boo
 }
 
 void Source::ClangView::async_delete() {
+  dispatcher.disconnect();
   delayed_reparse_connection.disconnect();
-  parse_postprocess_connection.disconnect();
-  parse_preprocess_connection.disconnect();
-  parse_error_connection.disconnect();
-  autocomplete_done_connection.disconnect();
-  autocomplete_restart_connection.disconnect();
-  autocomplete_error_connection.disconnect();
-  do_restart_parse_connection.disconnect();
   delayed_tag_similar_tokens_connection.disconnect();
   ClangViewAutocomplete::async_delete();
 }

--- a/src/source_clang.h
+++ b/src/source_clang.h
@@ -26,7 +26,6 @@ namespace Source {
     };
     
     ClangViewParse(const boost::filesystem::path &file_path, const boost::filesystem::path& project_path, Glib::RefPtr<Gsv::Language> language);
-    ~ClangViewParse() { dispatcher.disconnect(); }
     
     void configure() override;
     

--- a/src/source_clang.h
+++ b/src/source_clang.h
@@ -9,6 +9,7 @@
 #include "clangmm.h"
 #include "source.h"
 #include "terminal.h"
+#include "dispatcher.h"
 
 namespace Source {
   class ClangViewParse : public View {
@@ -25,11 +26,13 @@ namespace Source {
     };
     
     ClangViewParse(const boost::filesystem::path &file_path, const boost::filesystem::path& project_path, Glib::RefPtr<Gsv::Language> language);
+    ~ClangViewParse() { dispatcher.disconnect(); }
     
     void configure() override;
     
     void soft_reparse() override;
   protected:
+    Dispatcher dispatcher;
     void parse_initialize();
     std::unique_ptr<clang::TranslationUnit> clang_tu;
     std::unique_ptr<clang::Tokens> clang_tokens;
@@ -53,13 +56,7 @@ namespace Source {
     std::mutex parse_mutex;
     std::atomic<ParseState> parse_state;
     std::atomic<ParseProcessState> parse_process_state;
-    sigc::connection parse_preprocess_connection;
-    sigc::connection parse_postprocess_connection;
-    sigc::connection parse_error_connection;
   private:
-    Glib::Dispatcher parse_preprocess;
-    Glib::Dispatcher parse_postprocess;
-    Glib::Dispatcher parse_error;
     Glib::ustring parse_thread_buffer;
     
     void update_syntax();
@@ -90,29 +87,19 @@ namespace Source {
     bool on_key_press_event(GdkEventKey* key) override;
     
     std::thread autocomplete_thread;
-    sigc::connection autocomplete_done_connection;
-    sigc::connection autocomplete_restart_connection;
-    sigc::connection autocomplete_error_connection;
-    sigc::connection do_delete_object_connection;
-    sigc::connection do_restart_parse_connection;
   private:
     std::atomic<AutocompleteState> autocomplete_state;
     void autocomplete_dialog_setup();
     void autocomplete_check();
     void autocomplete();
-    std::vector<AutoCompleteData> autocomplete_data;
     std::unordered_map<std::string, std::pair<std::string, std::string> > autocomplete_dialog_rows;
     std::vector<AutoCompleteData> autocomplete_get_suggestions(const std::string &buffer, int line_number, int column);
     Tooltips autocomplete_tooltips;
-    Glib::Dispatcher autocomplete_done;
-    Glib::Dispatcher autocomplete_restart;
-    Glib::Dispatcher autocomplete_error;
     guint last_keyval=0;
     std::string prefix;
     std::mutex prefix_mutex;
     
     Glib::Dispatcher do_delete_object;
-    Glib::Dispatcher do_full_reparse;
     std::thread delete_thread;
     std::thread full_reparse_thread;
     bool full_reparse_running=false;

--- a/src/terminal.cc
+++ b/src/terminal.cc
@@ -2,9 +2,7 @@
 #include <iostream>
 #include "logging.h"
 #include "config.h"
-#ifdef JUCI_ENABLE_DEBUG
-#include "debug_clang.h"
-#endif
+#include "project.h"
 
 Terminal::InProgress::InProgress(const std::string& start_msg): stop(false) {
   start(start_msg);
@@ -240,7 +238,7 @@ bool Terminal::on_key_press_event(GdkEventKey *event) {
   processes_mutex.lock();
   bool debug_is_running=false;
 #ifdef JUCI_ENABLE_DEBUG
-  debug_is_running=DebugClang::get().is_running();
+  debug_is_running=Project::current_language?Project::current_language->debug_is_running():false;
 #endif
   if(processes.size()>0 || debug_is_running) {
     get_buffer()->place_cursor(get_buffer()->end());
@@ -262,7 +260,7 @@ bool Terminal::on_key_press_event(GdkEventKey *event) {
       stdin_buffer+='\n';
       if(debug_is_running) {
 #ifdef JUCI_ENABLE_DEBUG
-        DebugClang::get().write(stdin_buffer);
+        Project::current_language->debug_write(stdin_buffer);
 #endif
       }
       else

--- a/src/terminal.cc
+++ b/src/terminal.cc
@@ -3,7 +3,7 @@
 #include "logging.h"
 #include "config.h"
 #ifdef JUCI_ENABLE_DEBUG
-#include "debug.h"
+#include "debug_clang.h"
 #endif
 
 Terminal::InProgress::InProgress(const std::string& start_msg): stop(false) {
@@ -240,7 +240,7 @@ bool Terminal::on_key_press_event(GdkEventKey *event) {
   processes_mutex.lock();
   bool debug_is_running=false;
 #ifdef JUCI_ENABLE_DEBUG
-  debug_is_running=Debug::get().is_running();
+  debug_is_running=DebugClang::get().is_running();
 #endif
   if(processes.size()>0 || debug_is_running) {
     get_buffer()->place_cursor(get_buffer()->end());
@@ -262,7 +262,7 @@ bool Terminal::on_key_press_event(GdkEventKey *event) {
       stdin_buffer+='\n';
       if(debug_is_running) {
 #ifdef JUCI_ENABLE_DEBUG
-        Debug::get().write(stdin_buffer);
+        DebugClang::get().write(stdin_buffer);
 #endif
       }
       else

--- a/src/terminal.cc
+++ b/src/terminal.cc
@@ -212,13 +212,13 @@ std::shared_ptr<Terminal::InProgress> Terminal::print_in_progress(std::string st
 }
 
 void Terminal::async_print(const std::string &message, bool bold) {
-  dispatcher.add([this, message, bold] {
+  dispatcher.push([this, message, bold] {
     Terminal::get().print(message, bold);
   });
 }
 
 void Terminal::async_print(size_t line_nr, const std::string &message) {
-  dispatcher.add([this, line_nr, message] {
+  dispatcher.push([this, line_nr, message] {
     if(line_nr<deleted_lines)
       return;
     

--- a/src/terminal.h
+++ b/src/terminal.h
@@ -23,7 +23,6 @@ public:
     void start(const std::string& msg);
     size_t line_nr;
     std::atomic<bool> stop;
-    Dispatcher dispatcher;
     
     std::thread wait_thread;
   };
@@ -43,9 +42,9 @@ public:
   void kill_async_processes(bool force=false);
   
   size_t print(const std::string &message, bool bold=false);
-  void print(size_t line_nr, const std::string &message);
   std::shared_ptr<InProgress> print_in_progress(std::string start_msg);
   void async_print(const std::string &message, bool bold=false);
+  void async_print(size_t line_nr, const std::string &message);
 protected:
   bool on_key_press_event(GdkEventKey *event);
 private:

--- a/src/terminal.h
+++ b/src/terminal.h
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <iostream>
 #include "process.hpp"
+#include "dispatcher.h"
 
 class Terminal : public Gtk::TextView {
 public:
@@ -22,7 +23,8 @@ public:
     void start(const std::string& msg);
     size_t line_nr;
     std::atomic<bool> stop;
-    Glib::Dispatcher waiting_print;
+    Dispatcher dispatcher;
+    
     std::thread wait_thread;
   };
   
@@ -44,16 +46,10 @@ public:
   void print(size_t line_nr, const std::string &message);
   std::shared_ptr<InProgress> print_in_progress(std::string start_msg);
   void async_print(const std::string &message, bool bold=false);
-  void async_print(int line_nr, const std::string &message);
 protected:
   bool on_key_press_event(GdkEventKey *event);
 private:
-  Glib::Dispatcher async_print_dispatcher;
-  Glib::Dispatcher async_print_on_line_dispatcher;
-  std::vector<std::pair<std::string, bool> > async_print_strings;
-  std::vector<std::pair<int, std::string> > async_print_on_line_strings;
-  std::mutex async_print_strings_mutex;
-  std::mutex async_print_on_line_strings_mutex;
+  Dispatcher dispatcher;
   Glib::RefPtr<Gtk::TextTag> bold_tag;
 
   std::vector<std::shared_ptr<Process> > processes;

--- a/src/window.cc
+++ b/src/window.cc
@@ -54,7 +54,7 @@ Window::Window() : notebook(Notebook::get()) {
 #if GTK_VERSION_GE(3, 12)
   info_and_status_hbox.set_center_widget(*Project::debug_status_label);
 #else
-  Project::get().debug_status_label.set_halign(Gtk::Align::ALIGN_CENTER);
+  Project::debug_status_label.set_halign(Gtk::Align::ALIGN_CENTER);
   info_and_status_hbox.pack_start(*Project::debug_status_label);
 #endif
   info_and_status_hbox.pack_end(notebook.status, Gtk::PACK_SHRINK);

--- a/src/window.cc
+++ b/src/window.cc
@@ -536,9 +536,9 @@ void Window::set_menu_actions() {
     
     if(Config::get().project.save_on_compile_or_run)
       notebook.save_project_files();
-        
-    project_language=Project::get_language();
-    project_language->compile_and_run();
+    
+    Project::current_language=Project::get_language();
+    Project::current_language->compile_and_run();
   });
   menu.add_action("compile", [this]() {
     if(Project::compiling || Project::debugging)
@@ -547,8 +547,8 @@ void Window::set_menu_actions() {
     if(Config::get().project.save_on_compile_or_run)
       notebook.save_project_files();
         
-    project_language=Project::get_language();
-    project_language->compile();
+    Project::current_language=Project::get_language();
+    Project::current_language->compile();
   });
   
   menu.add_action("run_command", [this]() {
@@ -615,51 +615,51 @@ void Window::set_menu_actions() {
     if(Project::compiling)
       return;
     else if(Project::debugging) {
-      project_language->debug_continue();
+      Project::current_language->debug_continue();
       return;
     }
     
     if(Config::get().project.save_on_compile_or_run)
       notebook.save_project_files();
     
-    project_language=Project::get_language();
+    Project::current_language=Project::get_language();
     
-    project_language->debug_start();
+    Project::current_language->debug_start();
   });
   menu.add_action("debug_stop", [this]() {
-    if(project_language)
-      project_language->debug_stop();
+    if(Project::current_language)
+      Project::current_language->debug_stop();
   });
   menu.add_action("debug_kill", [this]() {
-    if(project_language)
-      project_language->debug_kill();
+    if(Project::current_language)
+      Project::current_language->debug_kill();
   });
   menu.add_action("debug_step_over", [this]() {
-    if(project_language)
-      project_language->debug_step_over();
+    if(Project::current_language)
+      Project::current_language->debug_step_over();
   });
   menu.add_action("debug_step_into", [this]() {
-    if(project_language)
-      project_language->debug_step_into();
+    if(Project::current_language)
+      Project::current_language->debug_step_into();
   });
   menu.add_action("debug_step_out", [this]() {
-    if(project_language)
-      project_language->debug_step_out();
+    if(Project::current_language)
+      Project::current_language->debug_step_out();
   });
   menu.add_action("debug_backtrace", [this]() {
-    if(project_language)
-      project_language->debug_backtrace();
+    if(Project::current_language)
+      Project::current_language->debug_backtrace();
   });
   menu.add_action("debug_show_variables", [this]() {
-    if(project_language)
-      project_language->debug_show_variables();
+    if(Project::current_language)
+      Project::current_language->debug_show_variables();
   });
   menu.add_action("debug_run_command", [this]() {
     entry_box.clear();
     entry_box.entries.emplace_back(last_run_debug_command, [this](const std::string& content){
       if(content!="") {
-        if(project_language)
-          project_language->debug_run_command(content);
+        if(Project::current_language)
+          Project::current_language->debug_run_command(content);
         last_run_debug_command=content;
       }
       entry_box.hide();
@@ -681,13 +681,13 @@ void Window::set_menu_actions() {
         auto end_iter=start_iter;
         while(!end_iter.ends_line() && end_iter.forward_char()) {}
         view->get_source_buffer()->remove_source_marks(start_iter, end_iter, "debug_breakpoint");
-        if(project_language)
-          project_language->debug_remove_breakpoint(view->file_path, line_nr+1, view->get_buffer()->get_line_count()+1);
+        if(Project::current_language)
+          Project::current_language->debug_remove_breakpoint(view->file_path, line_nr+1, view->get_buffer()->get_line_count()+1);
       }
       else {
         view->get_source_buffer()->create_source_mark("debug_breakpoint", view->get_buffer()->get_insert()->get_iter());
-        if(project_language)
-          project_language->debug_add_breakpoint(view->file_path, line_nr+1);
+        if(Project::current_language)
+          Project::current_language->debug_add_breakpoint(view->file_path, line_nr+1);
       }
     }
   });
@@ -817,8 +817,8 @@ bool Window::on_delete_event(GdkEventAny *event) {
   }
   Terminal::get().kill_async_processes();
 #ifdef JUCI_ENABLE_DEBUG
-  if(project_language)
-    project_language->debug_delete();
+  if(Project::current_language)
+    Project::current_language->debug_delete();
 #endif
   return false;
 }

--- a/src/window.cc
+++ b/src/window.cc
@@ -531,7 +531,7 @@ void Window::set_menu_actions() {
     entry_box.show();
   });
   menu.add_action("compile_and_run", [this]() {
-    if(Project::compiling)
+    if(Project::compiling || Project::debugging)
       return;
     
     if(Config::get().window.save_on_compile_or_run)
@@ -541,7 +541,7 @@ void Window::set_menu_actions() {
     project_language->compile_and_run();
   });
   menu.add_action("compile", [this]() {
-    if(Project::compiling)
+    if(Project::compiling || Project::debugging)
       return;
     
     if(Config::get().window.save_on_compile_or_run)
@@ -612,7 +612,9 @@ void Window::set_menu_actions() {
     entry_box.show();
   });
   menu.add_action("debug_start_continue", [this](){
-    if(Project::debugging) {
+    if(Project::compiling)
+      return;
+    else if(Project::debugging) {
       project_language->debug_continue();
       return;
     }

--- a/src/window.cc
+++ b/src/window.cc
@@ -681,12 +681,12 @@ void Window::set_menu_actions() {
         auto end_iter=start_iter;
         while(!end_iter.ends_line() && end_iter.forward_char()) {}
         view->get_source_buffer()->remove_source_marks(start_iter, end_iter, "debug_breakpoint");
-        if(Project::current_language)
+        if(Project::current_language && Project::debugging)
           Project::current_language->debug_remove_breakpoint(view->file_path, line_nr+1, view->get_buffer()->get_line_count()+1);
       }
       else {
         view->get_source_buffer()->create_source_mark("debug_breakpoint", view->get_buffer()->get_insert()->get_iter());
-        if(Project::current_language)
+        if(Project::current_language && Project::debugging)
           Project::current_language->debug_add_breakpoint(view->file_path, line_nr+1);
       }
     }

--- a/src/window.cc
+++ b/src/window.cc
@@ -575,7 +575,7 @@ void Window::set_menu_actions() {
   });
   
   menu.add_action("project_set_run_arguments", [this]() {
-    project=notebook.get_project();
+    project=get_project();
     auto run_arguments=std::make_shared<std::pair<std::string, std::string> >(project->get_run_arguments());
     if(run_arguments->second.empty())
       return;
@@ -605,7 +605,7 @@ void Window::set_menu_actions() {
     if(Config::get().window.save_on_compile_or_run)
       notebook.save_project_files();
         
-    project=notebook.get_project();
+    project=get_project();
     project->compile_and_run();
   });
   menu.add_action("compile", [this]() {
@@ -615,7 +615,7 @@ void Window::set_menu_actions() {
     if(Config::get().window.save_on_compile_or_run)
       notebook.save_project_files();
         
-    project=notebook.get_project();
+    project=get_project();
     project->compile();
   });
   
@@ -656,7 +656,7 @@ void Window::set_menu_actions() {
   
 #ifdef JUCI_ENABLE_DEBUG
   menu.add_action("debug_set_run_arguments", [this]() {
-    project=notebook.get_project();
+    project=get_project();
     auto run_arguments=std::make_shared<std::pair<std::string, std::string> >(project->debug_get_run_arguments());
     if(run_arguments->second.empty())
       return;
@@ -688,7 +688,7 @@ void Window::set_menu_actions() {
     if(Config::get().window.save_on_compile_or_run)
       notebook.save_project_files();
     
-    project=notebook.get_project();
+    project=get_project();
     
     project->debug_start([this](const std::string &status) {
       debug_status_mutex.lock();
@@ -1125,4 +1125,20 @@ void Window::rename_token_entry() {
       }
     }
   }
+}
+
+std::unique_ptr<Project> Window::get_project() {
+  if(notebook.get_current_page()!=-1) {
+    auto language_id=notebook.get_current_view()->language->get_id();
+    if(language_id=="markdown")
+      return std::unique_ptr<Project>(new ProjectMarkdown(notebook));
+    if(language_id=="python")
+      return std::unique_ptr<Project>(new ProjectPython(notebook));
+    if(language_id=="js")
+      return std::unique_ptr<Project>(new ProjectJavaScript(notebook));
+    if(language_id=="html")
+      return std::unique_ptr<Project>(new ProjectHTML(notebook));
+  }
+  
+  return std::unique_ptr<Project>(new ProjectClang(notebook));
 }

--- a/src/window.cc
+++ b/src/window.cc
@@ -667,14 +667,56 @@ void Window::set_menu_actions() {
     entry_box.show();
   });
   menu.add_action("debug_toggle_breakpoint", [this](){
-    if(Project::get().debugging)
-      project_language->toggle_breakpoint();
-    else
-      Project::get().get_language()->toggle_breakpoint();
+    if(notebook.get_current_page()!=-1) {
+      auto view=notebook.get_current_view();
+      auto line_nr=view->get_buffer()->get_insert()->get_iter().get_line();
+      
+      if(view->get_source_buffer()->get_source_marks_at_line(line_nr, "debug_breakpoint").size()>0) {
+        auto start_iter=view->get_buffer()->get_iter_at_line(line_nr);
+        auto end_iter=start_iter;
+        while(!end_iter.ends_line() && end_iter.forward_char()) {}
+        view->get_source_buffer()->remove_source_marks(start_iter, end_iter, "debug_breakpoint");
+        if(project_language)
+          project_language->debug_remove_breakpoint(view->file_path, line_nr+1, view->get_buffer()->get_line_count()+1);
+      }
+      else {
+        view->get_source_buffer()->create_source_mark("debug_breakpoint", view->get_buffer()->get_insert()->get_iter());
+        if(project_language)
+          project_language->debug_add_breakpoint(view->file_path, line_nr+1);
+      }
+    }
   });
   menu.add_action("debug_goto_stop", [this](){
-    if(project_language)
-      project_language->debug_goto_stop();
+    if(Project::get().debugging) {
+      auto &project=Project::get();
+      project.debug_stop_mutex.lock();
+      auto debug_stop_copy=project.debug_stop;
+      project.debug_stop_mutex.unlock();
+      if(!debug_stop_copy.first.empty()) {
+        notebook.open(debug_stop_copy.first);
+        if(notebook.get_current_page()!=-1) {
+          auto view=notebook.get_current_view();
+          
+          int line_nr=debug_stop_copy.second.first-1;
+          int line_index=debug_stop_copy.second.second-1;
+          if(line_nr<view->get_buffer()->get_line_count()) {
+            auto iter=view->get_buffer()->get_iter_at_line(line_nr);
+            auto end_line_iter=iter;
+            while(!iter.ends_line() && iter.forward_char()) {}
+            auto line=view->get_buffer()->get_text(iter, end_line_iter);
+            if(static_cast<size_t>(line_index)>=line.bytes())
+              line_index=0;
+            view->get_buffer()->place_cursor(view->get_buffer()->get_iter_at_line_index(line_nr, line_index));
+            
+            while(g_main_context_pending(NULL))
+              g_main_context_iteration(NULL, false);
+            if(notebook.get_current_page()!=-1 && notebook.get_current_view()==view)
+              view->scroll_to(view->get_buffer()->get_insert(), 0.0, 1.0, 0.5);
+          }
+          project.debug_update_stop();
+        }
+      }
+    }
   });
 #endif
   

--- a/src/window.cc
+++ b/src/window.cc
@@ -534,7 +534,7 @@ void Window::set_menu_actions() {
     if(Project::compiling || Project::debugging)
       return;
     
-    if(Config::get().window.save_on_compile_or_run)
+    if(Config::get().project.save_on_compile_or_run)
       notebook.save_project_files();
         
     project_language=Project::get_language();
@@ -544,7 +544,7 @@ void Window::set_menu_actions() {
     if(Project::compiling || Project::debugging)
       return;
     
-    if(Config::get().window.save_on_compile_or_run)
+    if(Config::get().project.save_on_compile_or_run)
       notebook.save_project_files();
         
     project_language=Project::get_language();
@@ -619,7 +619,7 @@ void Window::set_menu_actions() {
       return;
     }
     
-    if(Config::get().window.save_on_compile_or_run)
+    if(Config::get().project.save_on_compile_or_run)
       notebook.save_project_files();
     
     project_language=Project::get_language();

--- a/src/window.cc
+++ b/src/window.cc
@@ -54,7 +54,7 @@ Window::Window() : notebook(Notebook::get()) {
 #if GTK_VERSION_GE(3, 12)
   info_and_status_hbox.set_center_widget(*Project::debug_status_label);
 #else
-  Project::debug_status_label.set_halign(Gtk::Align::ALIGN_CENTER);
+  Project::debug_status_label->set_halign(Gtk::Align::ALIGN_CENTER);
   info_and_status_hbox.pack_start(*Project::debug_status_label);
 #endif
   info_and_status_hbox.pack_end(notebook.status, Gtk::PACK_SHRINK);

--- a/src/window.cc
+++ b/src/window.cc
@@ -26,8 +26,6 @@ Window::Window() : notebook(Notebook::get()) {
   set_title("juCi++");
   set_events(Gdk::POINTER_MOTION_MASK|Gdk::FOCUS_CHANGE_MASK|Gdk::SCROLL_MASK|Gdk::LEAVE_NOTIFY_MASK);
   
-  Project::debug_status_label=std::unique_ptr<Gtk::Label>(new Gtk::Label());
-  
   set_menu_actions();
     
   configure();
@@ -52,10 +50,10 @@ Window::Window() : notebook(Notebook::get()) {
   info_and_status_hbox.pack_start(notebook.info, Gtk::PACK_SHRINK);
   
 #if GTK_VERSION_GE(3, 12)
-  info_and_status_hbox.set_center_widget(*Project::debug_status_label);
+  info_and_status_hbox.set_center_widget(Project::debug_status_label());
 #else
-  Project::debug_status_label->set_halign(Gtk::Align::ALIGN_CENTER);
-  info_and_status_hbox.pack_start(*Project::debug_status_label);
+  Project::debug_status_label().set_halign(Gtk::Align::ALIGN_CENTER);
+  info_and_status_hbox.pack_start(Project::debug_status_label());
 #endif
   info_and_status_hbox.pack_end(notebook.status, Gtk::PACK_SHRINK);
   terminal_vbox.pack_end(info_and_status_hbox, Gtk::PACK_SHRINK);

--- a/src/window.cc
+++ b/src/window.cc
@@ -6,9 +6,6 @@
 //#include "api.h"
 #include "dialogs.h"
 #include "filesystem.h"
-#ifdef JUCI_ENABLE_DEBUG
-#include "debug.h"
-#endif
 
 namespace sigc {
 #ifndef SIGC_FUNCTORS_DEDUCE_RESULT_TYPE_WITH_DECLTYPE

--- a/src/window.h
+++ b/src/window.h
@@ -5,7 +5,6 @@
 #include "entrybox.h"
 #include "notebook.h"
 #include "cmake.h"
-#include "tooltips.h"
 #include "project.h"
 #include <atomic>
 
@@ -37,12 +36,8 @@ private:
   
   std::unique_ptr<Project> project;
   
-  std::atomic<bool> compiling;
-  
-  std::atomic<bool> debugging;
   Gtk::Label debug_status_label;
   
-  std::mutex debug_start_mutex;
   std::pair<boost::filesystem::path, std::pair<int, int> > debug_stop;
   boost::filesystem::path debug_last_stop_file_path;
   std::mutex debug_stop_mutex;
@@ -50,12 +45,6 @@ private:
   std::string debug_status;
   std::mutex debug_status_mutex;
   Glib::Dispatcher debug_update_status;
-  
-  Tooltips debug_variable_tooltips;
-
-  std::unique_ptr<CMake> get_cmake();
-  std::unordered_map<std::string, std::string> project_run_arguments;
-  std::unordered_map<std::string, std::string> debug_run_arguments;
 
   void configure();
   void set_menu_actions();

--- a/src/window.h
+++ b/src/window.h
@@ -6,6 +6,7 @@
 #include "notebook.h"
 #include "cmake.h"
 #include "tooltips.h"
+#include "project.h"
 #include <atomic>
 
 class Window : public Gtk::ApplicationWindow {
@@ -33,6 +34,8 @@ private:
   Gtk::HBox info_and_status_hbox;
   Gtk::AboutDialog about;
   EntryBox entry_box;
+  
+  std::unique_ptr<Project> project;
   
   std::atomic<bool> compiling;
   

--- a/src/window.h
+++ b/src/window.h
@@ -1,7 +1,7 @@
 #ifndef JUCI_WINDOW_H_
 #define JUCI_WINDOW_H_
 
-#include "gtkmm.h"
+#include <gtkmm.h>
 #include "entrybox.h"
 #include "notebook.h"
 #include "cmake.h"
@@ -11,13 +11,12 @@
 class Window : public Gtk::ApplicationWindow {
 private:
   Window();
+  Notebook &notebook; //convenience reference
 public:
   static Window &get() {
     static Window singleton;
     return singleton;
   }
-  
-  Notebook notebook;
 
 protected:
   bool on_key_press_event(GdkEventKey *event) override;
@@ -34,17 +33,7 @@ private:
   Gtk::AboutDialog about;
   EntryBox entry_box;
   
-  std::unique_ptr<Project> project;
-  
-  Gtk::Label debug_status_label;
-  
-  std::pair<boost::filesystem::path, std::pair<int, int> > debug_stop;
-  boost::filesystem::path debug_last_stop_file_path;
-  std::mutex debug_stop_mutex;
-  Glib::Dispatcher debug_update_stop;
-  std::string debug_status;
-  std::mutex debug_status_mutex;
-  Glib::Dispatcher debug_update_status;
+  std::unique_ptr<Project::Language> project_language;
 
   void configure();
   void set_menu_actions();
@@ -60,8 +49,6 @@ private:
   bool case_sensitive_search=true;
   bool regex_search=false;
   bool search_entry_shown=false;
-  
-  std::unique_ptr<Project> get_project();
 };
 
 #endif  // JUCI_WINDOW_H

--- a/src/window.h
+++ b/src/window.h
@@ -32,8 +32,6 @@ private:
   Gtk::HBox info_and_status_hbox;
   Gtk::AboutDialog about;
   EntryBox entry_box;
-  
-  std::unique_ptr<Project::Language> project_language;
 
   void configure();
   void set_menu_actions();

--- a/src/window.h
+++ b/src/window.h
@@ -60,6 +60,8 @@ private:
   bool case_sensitive_search=true;
   bool regex_search=false;
   bool search_entry_shown=false;
+  
+  std::unique_ptr<Project> get_project();
 };
 
 #endif  // JUCI_WINDOW_H


### PR DESCRIPTION
* Now supports running html, python, js and md files
* Window class now contains less code, moved some code to a new class Project and its subclasses
* ~~A bit of work left, want to move the remaining debug source code from Window to a Project singleton class for instance (not yet decided best way to do this)~~ 