### PR TITLE
Minor fixes

### DIFF
--- a/src/project.cc
+++ b/src/project.cc
@@ -168,10 +168,10 @@ void Project::Clang::compile_and_run() {
   
   compiling=true;
   Terminal::get().print("Compiling and running "+arguments+"\n");
-  Terminal::get().async_process(Config::get().project.make_command, default_build_path, [this, arguments, default_build_path](int exit_status){
+  Terminal::get().async_process(Config::get().project.make_command, default_build_path, [this, arguments, project_path](int exit_status){
     compiling=false;
     if(exit_status==EXIT_SUCCESS) {
-      Terminal::get().async_process(arguments, default_build_path, [this, arguments](int exit_status){
+      Terminal::get().async_process(arguments, project_path, [this, arguments](int exit_status){
         Terminal::get().async_print(arguments+" returned: "+std::to_string(exit_status)+'\n');
       });
     }
@@ -256,12 +256,12 @@ void Project::Clang::debug_start() {
   
   debugging=true;
   Terminal::get().print("Compiling and debugging "+run_arguments+"\n");
-  Terminal::get().async_process(Config::get().project.make_command, debug_build_path, [this, breakpoints, run_arguments, debug_build_path](int exit_status){
+  Terminal::get().async_process(Config::get().project.make_command, debug_build_path, [this, breakpoints, run_arguments, project_path](int exit_status){
     if(exit_status!=EXIT_SUCCESS)
       debugging=false;
     else {
       debug_start_mutex.lock();
-      Debug::Clang::get().start(run_arguments, debug_build_path, *breakpoints, [this, run_arguments](int exit_status){
+      Debug::Clang::get().start(run_arguments, project_path, *breakpoints, [this, run_arguments](int exit_status){
         debugging=false;
         Terminal::get().async_print(run_arguments+" returned: "+std::to_string(exit_status)+'\n');
       }, [this](const std::string &status) {

--- a/src/selectiondialog.cc
+++ b/src/selectiondialog.cc
@@ -38,6 +38,11 @@ void ListViewText::append(const std::string& value) {
   new_row->set_value(column_record.text, value);
 }
 
+void ListViewText::clear() {
+  unset_model();
+  list_store.reset();
+}
+
 SelectionDialogBase::SelectionDialogBase(Gtk::TextView& text_view, Glib::RefPtr<Gtk::TextBuffer::Mark> start_mark, bool show_search_entry, bool use_markup): text_view(text_view), 
 list_view_text(use_markup), start_mark(start_mark), show_search_entry(show_search_entry) {
   if(!show_search_entry)
@@ -117,6 +122,7 @@ void SelectionDialogBase::hide() {
   window->hide();
   if(on_hide)
     on_hide();
+  list_view_text.clear();
 }
 
 void SelectionDialogBase::move() {

--- a/src/selectiondialog.h
+++ b/src/selectiondialog.h
@@ -17,6 +17,7 @@ public:
   bool use_markup;
   ListViewText(bool use_markup);
   void append(const std::string& value);
+  void clear();
 private:
   Glib::RefPtr<Gtk::ListStore> list_store;
   ColumnRecord column_record;


### PR DESCRIPTION
@zalox merge this as well to your branch. Made the run path equal to the project path so that new C++ users can read and write files in the project path without adding a relative/absolute path. Also now safely clears the tree store when selection dialogs are hidden. 