### PR TITLE
replaced direct lock()/unlock() calls to mutex with unique_lock

### DIFF
--- a/src/debug_clang.cc
+++ b/src/debug_clang.cc
@@ -206,6 +206,7 @@ void Debug::Clang::start(const std::string &command, const boost::filesystem::pa
             Terminal::get().async_print(std::string(buffer, n), true);
         }
       }
+      lock.unlock();
       std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
   });

--- a/src/dispatcher.cc
+++ b/src/dispatcher.cc
@@ -2,26 +2,24 @@
 
 Dispatcher::Dispatcher() {
   connection=dispatcher.connect([this] {
-    functions_mutex.lock();
+    std::unique_lock<std::mutex> lock(functions_mutex);
     for(auto &function: functions) {
       function();
     }
     functions.clear();
-    functions_mutex.unlock();
   });
 }
 
 Dispatcher::~Dispatcher() {
   disconnect();
-  functions_mutex.lock();
+  std::unique_lock<std::mutex> lock(functions_mutex);
   functions.clear();
-  functions_mutex.unlock();
 }
 
 void Dispatcher::post(std::function<void()> &&function) {
-  functions_mutex.lock();
+  std::unique_lock<std::mutex> lock(functions_mutex);
   functions.emplace_back(function);
-  functions_mutex.unlock();
+  lock.unlock();
   dispatcher();
 }
 

--- a/src/project.cc
+++ b/src/project.cc
@@ -293,7 +293,7 @@ void Project::Clang::debug_start() {
     if(exit_status!=EXIT_SUCCESS)
       debugging=false;
     else {
-      debug_start_mutex.lock();
+      std::unique_lock<std::mutex> lock(debug_start_mutex);
       Debug::Clang::get().start(run_arguments, project_path, *breakpoints, [this, run_arguments](int exit_status){
         debugging=false;
         Terminal::get().async_print(run_arguments+" returned: "+std::to_string(exit_status)+'\n');
@@ -310,7 +310,6 @@ void Project::Clang::debug_start() {
           debug_update_stop();
         });
       });
-      debug_start_mutex.unlock();
     }
   });
 }
@@ -497,9 +496,8 @@ void Project::Clang::debug_write(const std::string &buffer) {
 }
 
 void Project::Clang::debug_delete() {
-  debug_start_mutex.lock();
+  std::unique_lock<std::mutex> lock(debug_start_mutex);
   Debug::Clang::get().delete_debug();
-  debug_start_mutex.unlock();
 }
 #endif
 


### PR DESCRIPTION
As per [`std::mutex::lock()`](http://en.cppreference.com/w/cpp/thread/mutex/lock) documentation:

> `lock()` is usually not called directly: `std::unique_lock` and `std::lock_guard` are used to manage exclusive locking. 

This is of course due to violated exception safety if any function throws.