### PR TITLE
changed main() created by "New C++ project" option

### DIFF
--- a/src/window.cc
+++ b/src/window.cc
@@ -218,7 +218,7 @@ void Window::set_menu_actions() {
         return;
       }
       std::string cmakelists="cmake_minimum_required(VERSION 2.8)\n\nproject("+project_name+")\n\nset(CMAKE_CXX_FLAGS \"${CMAKE_CXX_FLAGS} -std=c++1y -Wall -Wextra -Wno-unused-parameter\")\n\nadd_executable("+project_name+" main.cpp)\n";
-      std::string cpp_main="#include <iostream>\n\nusing namespace std;\n\nint main() {\n  cout << \"Hello World!\" << endl;\n\n  return 0;\n}\n";
+      std::string cpp_main="#include <iostream>\n\nint main() {\n  std::cout << \"Hello World!\\n\";\n}\n";
       if(filesystem::write(cmakelists_path, cmakelists) && filesystem::write(cpp_main_path, cpp_main)) {
         Directories::get().open(project_path);
         notebook.open(cpp_main_path);


### PR DESCRIPTION
removing `using namespace std;` and usage of `endl`, replacing it with `\n`

Usage of `using namespace std;` is [questionable](https://stackoverflow.com/questions/1452721/why-is-using-namespace-std-in-c-considered-bad-practice) and `std::endl` is a badly designed manipulator - it does a different thing that the name indicates: it outputs a newline *and* flushes the output. I've taken the liberty of removing `return 0;`, although I don't mind it that much.

Why does it matter for the IDE? Even though it's a minor point, the sample created by IDE should be *spotless*, as this is the first thing the Random Joe sees when he creates new project, it influences the first experience with the new IDE, so we don't want to encourage bad style in the samples. Also many other C++ IDEs fail the "Hello World test" - we can do better.