### PR TITLE
Fixed minor memory leak

### DIFF
--- a/src/project_build.cc
+++ b/src/project_build.cc
@@ -2,9 +2,9 @@
 #include "config.h"
 
 std::unique_ptr<Project::Build> Project::get_build(const boost::filesystem::path &path) {
-  auto cmake=new CMake(path);
+  std::unique_ptr<Project::Build> cmake(new CMake(path));
   if(!cmake->project_path.empty())
-    return std::unique_ptr<Project::Build>(cmake);
+    return cmake;
   else
     return std::unique_ptr<Project::Build>(new Project::Build());
 }


### PR DESCRIPTION
Nuke raw calls to `new` from orbit, any one of them becomes a potential to leak.

I'm seriously considering backporting `make_unique` and replacing all calls to `new` with it.