### PR TITLE
Enable Continuous Integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,27 @@
 sudo: required
-dist: trusty
+language: cpp
 
+env:
+  - distribution: ubuntu
+    version: 16.04
+    init: /sbin/init
+    run_opts: ""
+  - distribution: fedora
+    version: 23
+    init: /sbin/init
+    run_opts: ""
+
+services:
+  - docker
+  
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y git cmake make g++ libclang-3.5-dev liblldb-3.5-dev clang-format-3.5 pkg-config libboost-filesystem-dev libboost-regex-dev libgtksourceviewmm-3.0-dev aspell-en libaspell-dev
+  - sudo docker pull ${distribution}:${version}
+  - sudo docker build --rm=true --file=ci/${distribution}-${version}.docker --tag=${distribution}-${version}:jucipp ci
 
 script:
-  - git submodule update
-  - mkdir build
-  - cd build
-  - cmake -DCMAKE_CXX_COMPILER=g++ ..
-  - make
+  - container_id=$(mktemp)
+  - sudo docker run --detach --volume="${PWD}":/home/:rw ${run_opts} ${distribution}-${version}:jucipp "${init}" > "${container_id}"
+  
+  - sudo docker exec "$(cat ${container_id})" /home/ci/${distribution}-${version}.build
+  
+  - sudo docker stop "$(cat ${container_id})"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+dist: trusty
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y git cmake make g++ libclang-3.5-dev liblldb-3.5-dev clang-format-3.5 pkg-config libboost-filesystem-dev libboost-regex-dev libgtksourceviewmm-3.0-dev aspell-en libaspell-dev
+
+script:
+  - git submodule update
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_CXX_COMPILER=g++ ..
+  - make

--- a/ci/fedora-23.build
+++ b/ci/fedora-23.build
@@ -1,0 +1,6 @@
+#!/bin/bash
+cd /home &&
+mkdir build &&
+cd build &&
+cmake -DCMAKE_CXX_COMPILER=g++ .. &&
+make

--- a/ci/fedora-23.docker
+++ b/ci/fedora-23.docker
@@ -1,0 +1,3 @@
+FROM fedora:23
+
+RUN dnf install -y git cmake make gcc-c++ clang-devel clang lldb-devel boost-devel gtksourceviewmm3-devel gtkmm30-devel aspell-devel aspell-en

--- a/ci/ubuntu-16.04.build
+++ b/ci/ubuntu-16.04.build
@@ -1,0 +1,6 @@
+#!/bin/bash
+cd /home &&
+mkdir build &&
+cd build &&
+cmake -DCMAKE_CXX_COMPILER=g++ .. &&
+make

--- a/ci/ubuntu-16.04.docker
+++ b/ci/ubuntu-16.04.docker
@@ -6,9 +6,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
       cmake \
       make \
       g++ \
-      libclang-3.5-dev \
-      liblldb-3.5-dev \
-      clang-format-3.5 \
+      libclang-3.6-dev \
+      liblldb-3.6-dev \
+      clang-format-3.6 \
       pkg-config \
       libboost-filesystem-dev \
       libboost-regex-dev \

--- a/ci/ubuntu-16.04.docker
+++ b/ci/ubuntu-16.04.docker
@@ -1,4 +1,18 @@
 FROM ubuntu:16.04
 
-RUN apt-get update
-RUN apt-get install -y git cmake make g++ libclang-3.5-dev liblldb-3.5-dev clang-format-3.5 pkg-config libboost-filesystem-dev libboost-regex-dev libgtksourceviewmm-3.0-dev aspell-en libaspell-dev
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+&& apt-get install -y \
+      git \
+      cmake \
+      make \
+      g++ \
+      libclang-3.5-dev \
+      liblldb-3.5-dev \
+      clang-format-3.5 \
+      pkg-config \
+      libboost-filesystem-dev \
+      libboost-regex-dev \
+      libgtksourceviewmm-3.0-dev \
+      aspell-en \
+      libaspell-dev \
+&& rm -rf /var/lib/apt/lists/*

--- a/ci/ubuntu-16.04.docker
+++ b/ci/ubuntu-16.04.docker
@@ -1,0 +1,4 @@
+FROM ubuntu:16.04
+
+RUN apt-get update
+RUN apt-get install -y git cmake make g++ libclang-3.5-dev liblldb-3.5-dev clang-format-3.5 pkg-config libboost-filesystem-dev libboost-regex-dev libgtksourceviewmm-3.0-dev aspell-en libaspell-dev


### PR DESCRIPTION
For now it doesn't do much (only builds it), but in the future it could run tests, generate packages and so on.

To enable this you need to connect the GitHub account to the free version of Travis CI on https://travis-ci.org/ - once you register there, you can enable CI for specific repositories.