### PR TITLE
Added: Go to Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ towards libclang with speed and ease of use in mind.
 * Rename refactoring across files (C++)
 * Highlighting of similar types (C++)
 * Automated documentation search (C++)
-* Go to methods and usages (C++)
+* Go to declaration, implementation, methods and usages (C++)
 * Spell checking depending on file context
 * Run shell commands within JuCi++
 * Regex search and replace

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,4 +16,4 @@ make doc
 ```
 
 ## Where is the generated API documentation
-Open jupicpp/build/src/html/index.html
+Open jucipp/build/src/html/index.html

--- a/src/files.h
+++ b/src/files.h
@@ -2,7 +2,7 @@
 #define JUCI_FILES_H_
 #include <string>
 
-#define JUCI_VERSION "1.1.3"
+#define JUCI_VERSION "1.1.3-1"
 
 const std::string configjson =
 "{\n"
@@ -92,6 +92,7 @@ const std::string configjson =
 "        \"source_center_cursor\": \"<primary>l\",\n"
 "        \"source_find_documentation\": \"<primary><shift>d\",\n"
 "        \"source_goto_declaration\": \"<primary>d\",\n"
+"        \"source_goto_implementation\": \"<primary>i\",\n"
 "        \"source_goto_usage\": \"<primary>u\",\n"
 "        \"source_goto_method\": \"<primary>m\",\n"
 "        \"source_rename\": \"<primary>r\",\n"

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -213,6 +213,11 @@ Menu::Menu() {
              +accels["source_goto_declaration"]+ //For Ubuntu...
   "        </item>"
   "        <item>"
+  "          <attribute name='label' translatable='yes'>_Go to Implementation</attribute>"
+  "          <attribute name='action'>app.source_goto_implementation</attribute>"
+             +accels["source_goto_implementation"]+ //For Ubuntu...
+  "        </item>"
+  "        <item>"
   "          <attribute name='label' translatable='yes'>_Go to Usage</attribute>"
   "          <attribute name='action'>app.source_goto_usage</attribute>"
              +accels["source_goto_usage"]+ //For Ubuntu...

--- a/src/source.h
+++ b/src/source.h
@@ -78,6 +78,7 @@ namespace Source {
     
     std::function<void()> auto_indent;
     std::function<Offset()> get_declaration_location;
+    std::function<Offset(const Token &token)> get_implementation_location;
     std::function<std::vector<std::pair<Offset, std::string> >(const Token &token)> get_usages;
     std::function<void()> goto_method;
     std::function<Token()> get_token;

--- a/src/source_clang.cc
+++ b/src/source_clang.cc
@@ -922,19 +922,20 @@ Source::ClangViewAutocomplete(file_path, language) {
   get_implementation_location=[this](const Token &token){
     Offset location;
     if(parsed && this->language && this->language->get_id()!="chdr" && this->language->get_id()!="cpphdr") {
-      for(auto &a_token: *clang_tokens) {
-        auto cursor=a_token.get_cursor();
+      for(auto token_it=clang_tokens->rbegin();token_it!=clang_tokens->rend();++token_it) {
+        auto cursor=token_it->get_cursor();
         auto kind=cursor.get_kind();
-        if((kind==clang::CursorKind::CXXMethod || kind==clang::CursorKind::Constructor || kind==clang::CursorKind::Destructor) &&
-           a_token.get_kind()==clang::Token_Identifier && cursor.has_type()) {
+        if((kind==clang::CursorKind::FunctionDecl || kind==clang::CursorKind::CXXMethod ||
+            kind==clang::CursorKind::Constructor || kind==clang::CursorKind::Destructor) &&
+           token_it->get_kind()==clang::Token_Identifier && cursor.has_type()) {
           auto referenced=cursor.get_referenced();
           if(referenced && static_cast<clang::CursorKind>(token.type)==referenced.get_kind() &&
-             token.spelling==a_token.get_spelling() && token.usr==referenced.get_usr()) {
+             token.spelling==token_it->get_spelling() && token.usr==referenced.get_usr()) {
             location.file_path=cursor.get_source_location().get_path();
             auto clang_offset=cursor.get_source_location().get_offset();
             location.line=clang_offset.line;
             location.index=clang_offset.index;
-            //do not break here, choose last occurrence in case declaration and implementation is in the same file
+            break;
           }
         }
       }

--- a/src/window.cc
+++ b/src/window.cc
@@ -426,7 +426,7 @@ void Window::set_menu_actions() {
           boost::system::error_code ec;
           declaration_file=boost::filesystem::canonical(location.file_path, ec);
           if(ec)
-            declaration_file=location.file_path;
+            return;
           notebook.open(declaration_file);
           auto line=static_cast<int>(location.line)-1;
           auto index=static_cast<int>(location.index)-1;
@@ -441,6 +441,45 @@ void Window::set_menu_actions() {
             
             view->get_buffer()->place_cursor(view->get_buffer()->get_iter_at_line_index(line, index));
             view->scroll_to_cursor_delayed(view, true, false);
+          }
+        }
+      }
+    }
+  });
+  menu.add_action("source_goto_implementation", [this]() {
+    if(notebook.get_current_page()!=-1) {
+      auto current_view=notebook.get_current_view();
+      if(current_view->get_token) {
+        auto token=current_view->get_token();
+        if(token) {
+          for(int page=0;page<notebook.size();page++) {
+            auto view=notebook.get_view(page);
+            if(view->get_implementation_location) {
+              auto location=view->get_implementation_location(token);
+              if(!location.file_path.empty()) {
+                boost::filesystem::path implementation_path;
+                boost::system::error_code ec;
+                implementation_path=boost::filesystem::canonical(location.file_path, ec);
+                if(ec)
+                  return;
+                notebook.open(implementation_path);
+                auto line=static_cast<int>(location.line)-1;
+                auto index=static_cast<int>(location.index)-1;
+                auto view=notebook.get_current_view();
+                line=std::min(line, view->get_buffer()->get_line_count()-1);
+                if(line>=0) {
+                  auto iter=view->get_buffer()->get_iter_at_line(line);
+                  while(!iter.ends_line())
+                    iter.forward_char();
+                  auto end_line_index=iter.get_line_index();
+                  index=std::min(index, end_line_index);
+                  
+                  view->get_buffer()->place_cursor(view->get_buffer()->get_iter_at_line_index(line, index));
+                  view->scroll_to_cursor_delayed(view, true, false);
+                }
+                return;
+              }
+            }
           }
         }
       }
@@ -488,7 +527,7 @@ void Window::set_menu_actions() {
             boost::system::error_code ec;
             declaration_file=boost::filesystem::canonical(offset.file_path, ec);
             if(ec)
-              declaration_file=offset.file_path;
+              return;
             notebook.open(declaration_file);
             auto view=notebook.get_current_view();
             view->get_buffer()->place_cursor(view->get_buffer()->get_iter_at_line_index(offset.line, offset.index));
@@ -776,6 +815,7 @@ void Window::activate_menu_items(bool activate) {
   menu.actions["source_indentation_auto_indent_buffer"]->set_enabled(activate ? static_cast<bool>(notebook.get_current_view()->auto_indent) : false);
   menu.actions["source_find_documentation"]->set_enabled(activate ? static_cast<bool>(notebook.get_current_view()->get_token_data) : false);
   menu.actions["source_goto_declaration"]->set_enabled(activate ? static_cast<bool>(notebook.get_current_view()->get_declaration_location) : false);
+  menu.actions["source_goto_implementation"]->set_enabled(activate ? static_cast<bool>(notebook.get_current_view()->get_implementation_location) : false);
   menu.actions["source_goto_usage"]->set_enabled(activate ? static_cast<bool>(notebook.get_current_view()->get_usages) : false);
   menu.actions["source_goto_method"]->set_enabled(activate ? static_cast<bool>(notebook.get_current_view()->goto_method) : false);
   menu.actions["source_rename"]->set_enabled(activate ? static_cast<bool>(notebook.get_current_view()->rename_similar_tokens) : false);


### PR DESCRIPTION
Works if implementation file is opened and parsed. Header files are not considered, use Go to Declaration instead then. Still pretty useful.