### PR TITLE
Add draw_spaces option

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -186,6 +186,7 @@ void Config::get_source() {
   source.font=source_json.get<std::string>("font");
 
   source.cleanup_whitespace_characters=source_json.get<bool>("cleanup_whitespace_characters");
+  source.draw_spaces=source_json.get<std::string>("draw_spaces");
 
   source.show_map = source_json.get<bool>("show_map");
   source.map_font_size = source_json.get<std::string>("map_font_size");

--- a/src/config.h
+++ b/src/config.h
@@ -56,6 +56,7 @@ public:
     std::string spellcheck_language;
     
     bool cleanup_whitespace_characters;
+    std::string draw_spaces;
     
     bool show_map;
     std::string map_font_size;

--- a/src/files.h
+++ b/src/files.h
@@ -2,7 +2,7 @@
 #define JUCI_FILES_H_
 #include <string>
 
-#define JUCI_VERSION "1.1.3-1"
+#define JUCI_VERSION "1.1.3-2"
 
 const std::string configjson =
 "{\n"

--- a/src/files.h
+++ b/src/files.h
@@ -38,7 +38,7 @@ const std::string configjson =
 "        \"cleanup_whitespace_characters_comment\": \"Remove trailing whitespace characters on save, and add trailing newline if missing\",\n"
 "        \"cleanup_whitespace_characters\": false,\n"
 "        \"draw_spaces_comment\": \"Determines what kind of whitespaces should be drawn. Use comma-separated list of: space, tab, newline, nbsp, leading, text, trailing or all\",\n"
-"        \"draw_spaces\": \"space, tab, nbsp, trailing\",\n"
+"        \"draw_spaces\": \"\",\n"
 "        \"show_map\": true,\n"
 "        \"map_font_size\": \"1\",\n"
 "        \"spellcheck_language_comment\": \"Use \\\"\\\" to set language from your locale settings\",\n"

--- a/src/files.h
+++ b/src/files.h
@@ -37,6 +37,8 @@ const std::string configjson =
 #endif
 "        \"cleanup_whitespace_characters_comment\": \"Remove trailing whitespace characters on save, and add trailing newline if missing\",\n"
 "        \"cleanup_whitespace_characters\": false,\n"
+"        \"draw_spaces_comment\": \"Determines what kind of whitespaces should be drawn. Use comma-separated list of: space, tab, newline, nbsp, leading, text, trailing or all\",\n"
+"        \"draw_spaces\": \"space, tab, nbsp, trailing\",\n"
 "        \"show_map\": true,\n"
 "        \"map_font_size\": \"1\",\n"
 "        \"spellcheck_language_comment\": \"Use \\\"\\\" to set language from your locale settings\",\n"

--- a/src/source.cc
+++ b/src/source.cc
@@ -4,7 +4,9 @@
 #include "terminal.h"
 
 #include <boost/property_tree/json_parser.hpp>
-#include <boost/spirit/include/qi.hpp>
+#include <boost/spirit/home/qi/char.hpp>
+#include <boost/spirit/home/qi/operator.hpp>
+#include <boost/spirit/home/qi/string.hpp>
 
 #include <gtksourceview/gtksource.h>
 


### PR DESCRIPTION
Determines what kind of whitespaces should be drawn. Use comma-separated
list of: space, tab, newline, nbsp, leading, text, trailing or all.