### PR TITLE
Refactor: src/project* files

### DIFF
--- a/src/project.h
+++ b/src/project.h
@@ -25,10 +25,10 @@ namespace Project {
   void debug_update_stop();
   void debug_update_status(const std::string &debug_status);
   
-  class Language {
+  class Base {
   public:
-    Language(std::unique_ptr<Build> &&build): build(std::move(build)) {}
-    virtual ~Language() {}
+    Base(std::unique_ptr<Build> &&build): build(std::move(build)) {}
+    virtual ~Base() {}
     
     std::unique_ptr<Build> build;
     
@@ -55,11 +55,11 @@ namespace Project {
     virtual void debug_delete() {}
   };
   
-  class Clang : public Language {
+  class Clang : public Base {
   private:
     Dispatcher dispatcher;
   public:
-    Clang(std::unique_ptr<Build> &&build) : Language(std::move(build)) {}
+    Clang(std::unique_ptr<Build> &&build) : Base(std::move(build)) {}
     ~Clang() { dispatcher.disconnect(); }
     
     std::pair<std::string, std::string> get_run_arguments() override;
@@ -87,38 +87,38 @@ namespace Project {
   #endif
   };
   
-  class Markdown : public Language {
+  class Markdown : public Base {
   public:
-    Markdown(std::unique_ptr<Build> &&build) : Language(std::move(build)) {}
+    Markdown(std::unique_ptr<Build> &&build) : Base(std::move(build)) {}
     ~Markdown();
     
     boost::filesystem::path last_temp_path;
     void compile_and_run() override;
   };
   
-  class Python : public Language {
+  class Python : public Base {
   public:
-    Python(std::unique_ptr<Build> &&build) : Language(std::move(build)) {}
+    Python(std::unique_ptr<Build> &&build) : Base(std::move(build)) {}
     
     void compile_and_run() override;
   };
   
-  class JavaScript : public Language {
+  class JavaScript : public Base {
   public:
-    JavaScript(std::unique_ptr<Build> &&build) : Language(std::move(build)) {}
+    JavaScript(std::unique_ptr<Build> &&build) : Base(std::move(build)) {}
     
     void compile_and_run() override;
   };
   
-  class HTML : public Language {
+  class HTML : public Base {
   public:
-    HTML(std::unique_ptr<Build> &&build) : Language(std::move(build)) {}
+    HTML(std::unique_ptr<Build> &&build) : Base(std::move(build)) {}
     
     void compile_and_run() override;
   };
   
-  std::unique_ptr<Language> get_language();
-  extern std::unique_ptr<Language> current_language;
+  std::unique_ptr<Base> create();
+  extern std::unique_ptr<Base> current;
 };
 
 #endif  // JUCI_PROJECT_H_

--- a/src/project_build.cc
+++ b/src/project_build.cc
@@ -2,8 +2,8 @@
 #include "config.h"
 #include "info.h"
 
-std::unique_ptr<Project::Build> Project::get_build(const boost::filesystem::path &path) {
-  std::unique_ptr<Project::Build> cmake(new CMake(path));
+std::unique_ptr<Project::Build> Project::Build::create(const boost::filesystem::path &path) {
+  std::unique_ptr<Project::Build> cmake(new CMakeBuild(path));
   if(!cmake->project_path.empty())
     return cmake;
   else {
@@ -12,7 +12,7 @@ std::unique_ptr<Project::Build> Project::get_build(const boost::filesystem::path
   }
 }
 
-boost::filesystem::path Project::Build::get_default_build_path() {
+boost::filesystem::path Project::Build::get_default_path() {
   if(project_path.empty())
     return boost::filesystem::path();
     
@@ -35,7 +35,7 @@ boost::filesystem::path Project::Build::get_default_build_path() {
   return default_build_path;
 }
 
-boost::filesystem::path Project::Build::get_debug_build_path() {
+boost::filesystem::path Project::Build::get_debug_path() {
   if(project_path.empty())
     return boost::filesystem::path();
   
@@ -69,18 +69,18 @@ boost::filesystem::path Project::Build::get_debug_build_path() {
   return debug_build_path;
 }
 
-Project::CMake::CMake(const boost::filesystem::path &path) : Project::Build(), cmake(path) {
+Project::CMakeBuild::CMakeBuild(const boost::filesystem::path &path) : Project::Build(), cmake(path) {
   project_path=cmake.project_path;
 }
 
-bool Project::CMake::update_default_build(bool force) {
-  return cmake.update_default_build(get_default_build_path(), force);
+bool Project::CMakeBuild::update_default(bool force) {
+  return cmake.update_default_build(get_default_path(), force);
 }
 
-bool Project::CMake::update_debug_build(bool force) {
-  return cmake.update_debug_build(get_debug_build_path(), force);
+bool Project::CMakeBuild::update_debug(bool force) {
+  return cmake.update_debug_build(get_debug_path(), force);
 }
 
-boost::filesystem::path Project::CMake::get_executable(const boost::filesystem::path &path) {
+boost::filesystem::path Project::CMakeBuild::get_executable(const boost::filesystem::path &path) {
   return cmake.get_executable(path);
 }

--- a/src/project_build.h
+++ b/src/project_build.h
@@ -12,26 +12,26 @@ namespace Project {
     
     boost::filesystem::path project_path;
     
-    boost::filesystem::path get_default_build_path();
-    virtual bool update_default_build(bool force=false) {return false;}
-    boost::filesystem::path get_debug_build_path();
-    virtual bool update_debug_build(bool force=false) {return false;}
+    boost::filesystem::path get_default_path();
+    virtual bool update_default(bool force=false) {return false;}
+    boost::filesystem::path get_debug_path();
+    virtual bool update_debug(bool force=false) {return false;}
     
     virtual boost::filesystem::path get_executable(const boost::filesystem::path &path) {return boost::filesystem::path();}
+    
+    static std::unique_ptr<Build> create(const boost::filesystem::path &path);
   };
   
-  class CMake : public Build {
+  class CMakeBuild : public Build {
     ::CMake cmake;
   public:
-    CMake(const boost::filesystem::path &path);
+    CMakeBuild(const boost::filesystem::path &path);
     
-    bool update_default_build(bool force=false) override;
-    bool update_debug_build(bool force=false) override;
+    bool update_default(bool force=false) override;
+    bool update_debug(bool force=false) override;
     
     boost::filesystem::path get_executable(const boost::filesystem::path &path) override;
   };
-  
-  std::unique_ptr<Build> get_build(const boost::filesystem::path &path);
 }
 
 #endif // JUCI_PROJECT_BUILD_H_

--- a/src/source_clang.cc
+++ b/src/source_clang.cc
@@ -174,9 +174,9 @@ void Source::ClangViewParse::soft_reparse() {
 }
 
 std::vector<std::string> Source::ClangViewParse::get_compilation_commands() {
-  auto build=Project::get_build(file_path);
-  auto default_build_path=build->get_default_build_path();
-  build->update_default_build();
+  auto build=Project::Build::create(file_path);
+  auto default_build_path=build->get_default_path();
+  build->update_default();
   clang::CompilationDatabase db(default_build_path.string());
   clang::CompileCommands commands(file_path.string(), db);
   std::vector<clang::CompileCommand> cmds = commands.get_commands();

--- a/src/terminal.cc
+++ b/src/terminal.cc
@@ -362,8 +362,8 @@ bool Terminal::on_button_press_event(GdkEventButton* button_event) {
         auto path=boost::filesystem::path(path_str);
         boost::system::error_code ec;
         if(path.is_relative()) {
-          if(Project::current_language)
-            path=boost::filesystem::canonical(Project::current_language->build->get_default_build_path()/path_str, ec);
+          if(Project::current)
+            path=boost::filesystem::canonical(Project::current->build->get_default_path()/path_str, ec);
           else
             return Gtk::TextView::on_button_press_event(button_event);
         }
@@ -393,7 +393,7 @@ bool Terminal::on_key_press_event(GdkEventKey *event) {
   std::unique_lock<std::mutex> lock(processes_mutex);
   bool debug_is_running=false;
 #ifdef JUCI_ENABLE_DEBUG
-  debug_is_running=Project::current_language?Project::current_language->debug_is_running():false;
+  debug_is_running=Project::current?Project::current->debug_is_running():false;
 #endif
   if(processes.size()>0 || debug_is_running) {
     get_buffer()->place_cursor(get_buffer()->end());
@@ -415,7 +415,7 @@ bool Terminal::on_key_press_event(GdkEventKey *event) {
       stdin_buffer+='\n';
       if(debug_is_running) {
 #ifdef JUCI_ENABLE_DEBUG
-        Project::current_language->debug_write(stdin_buffer);
+        Project::current->debug_write(stdin_buffer);
 #endif
       }
       else

--- a/src/window.cc
+++ b/src/window.cc
@@ -558,7 +558,7 @@ void Window::set_menu_actions() {
   });
   
   menu.add_action("project_set_run_arguments", [this]() {
-    auto project_language=Project::get_language();
+    auto project_language=Project::create();
     auto run_arguments=std::make_shared<std::pair<std::string, std::string> >(project_language->get_run_arguments());
     if(run_arguments->second.empty())
       return;
@@ -587,12 +587,12 @@ void Window::set_menu_actions() {
       return;
     }
     
-    Project::current_language=Project::get_language();
+    Project::current=Project::create();
     
     if(Config::get().project.save_on_compile_or_run)
-      Project::save_files(Project::current_language->build->project_path);
+      Project::save_files(Project::current->build->project_path);
     
-    Project::current_language->compile_and_run();
+    Project::current->compile_and_run();
   });
   menu.add_action("compile", [this]() {
     if(Project::compiling || Project::debugging) {
@@ -600,12 +600,12 @@ void Window::set_menu_actions() {
       return;
     }
             
-    Project::current_language=Project::get_language();
+    Project::current=Project::create();
     
     if(Config::get().project.save_on_compile_or_run)
-      Project::save_files(Project::current_language->build->project_path);
+      Project::save_files(Project::current->build->project_path);
     
-    Project::current_language->compile();
+    Project::current->compile();
   });
   
   menu.add_action("run_command", [this]() {
@@ -645,7 +645,7 @@ void Window::set_menu_actions() {
   
 #ifdef JUCI_ENABLE_DEBUG
   menu.add_action("debug_set_run_arguments", [this]() {
-    auto project_language=Project::get_language();
+    auto project_language=Project::create();
     auto run_arguments=std::make_shared<std::pair<std::string, std::string> >(project_language->debug_get_run_arguments());
     if(run_arguments->second.empty())
       return;
@@ -674,51 +674,51 @@ void Window::set_menu_actions() {
       return;
     }
     else if(Project::debugging) {
-      Project::current_language->debug_continue();
+      Project::current->debug_continue();
       return;
     }
         
-    Project::current_language=Project::get_language();
+    Project::current=Project::create();
     
     if(Config::get().project.save_on_compile_or_run)
-      Project::save_files(Project::current_language->build->project_path);
+      Project::save_files(Project::current->build->project_path);
     
-    Project::current_language->debug_start();
+    Project::current->debug_start();
   });
   menu.add_action("debug_stop", [this]() {
-    if(Project::current_language)
-      Project::current_language->debug_stop();
+    if(Project::current)
+      Project::current->debug_stop();
   });
   menu.add_action("debug_kill", [this]() {
-    if(Project::current_language)
-      Project::current_language->debug_kill();
+    if(Project::current)
+      Project::current->debug_kill();
   });
   menu.add_action("debug_step_over", [this]() {
-    if(Project::current_language)
-      Project::current_language->debug_step_over();
+    if(Project::current)
+      Project::current->debug_step_over();
   });
   menu.add_action("debug_step_into", [this]() {
-    if(Project::current_language)
-      Project::current_language->debug_step_into();
+    if(Project::current)
+      Project::current->debug_step_into();
   });
   menu.add_action("debug_step_out", [this]() {
-    if(Project::current_language)
-      Project::current_language->debug_step_out();
+    if(Project::current)
+      Project::current->debug_step_out();
   });
   menu.add_action("debug_backtrace", [this]() {
-    if(Project::current_language)
-      Project::current_language->debug_backtrace();
+    if(Project::current)
+      Project::current->debug_backtrace();
   });
   menu.add_action("debug_show_variables", [this]() {
-    if(Project::current_language)
-      Project::current_language->debug_show_variables();
+    if(Project::current)
+      Project::current->debug_show_variables();
   });
   menu.add_action("debug_run_command", [this]() {
     EntryBox::get().clear();
     EntryBox::get().entries.emplace_back(last_run_debug_command, [this](const std::string& content){
       if(content!="") {
-        if(Project::current_language)
-          Project::current_language->debug_run_command(content);
+        if(Project::current)
+          Project::current->debug_run_command(content);
         last_run_debug_command=content;
       }
       EntryBox::get().hide();
@@ -740,13 +740,13 @@ void Window::set_menu_actions() {
         auto end_iter=start_iter;
         while(!end_iter.ends_line() && end_iter.forward_char()) {}
         view->get_source_buffer()->remove_source_marks(start_iter, end_iter, "debug_breakpoint");
-        if(Project::current_language && Project::debugging)
-          Project::current_language->debug_remove_breakpoint(view->file_path, line_nr+1, view->get_buffer()->get_line_count()+1);
+        if(Project::current && Project::debugging)
+          Project::current->debug_remove_breakpoint(view->file_path, line_nr+1, view->get_buffer()->get_line_count()+1);
       }
       else {
         view->get_source_buffer()->create_source_mark("debug_breakpoint", view->get_buffer()->get_insert()->get_iter());
-        if(Project::current_language && Project::debugging)
-          Project::current_language->debug_add_breakpoint(view->file_path, line_nr+1);
+        if(Project::current && Project::debugging)
+          Project::current->debug_add_breakpoint(view->file_path, line_nr+1);
       }
     }
   });
@@ -880,8 +880,8 @@ bool Window::on_delete_event(GdkEventAny *event) {
   }
   Terminal::get().kill_async_processes();
 #ifdef JUCI_ENABLE_DEBUG
-  if(Project::current_language)
-    Project::current_language->debug_delete();
+  if(Project::current)
+    Project::current->debug_delete();
 #endif
   return false;
 }


### PR DESCRIPTION
I'm much more happy with the project files now, and its usage is more readable and makes more sense to new contributors I think. 

::create is used in gtkmm for creating new special instances, so I stuck to this pattern. 

@zalox Refactorings such as these are pretty safe, but have tested on most platforms. Merge whenever:)