### PR TITLE
Added initial tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,3 +9,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|OpenBSD|NetBSD")
     install(FILES "${CMAKE_SOURCE_DIR}/share/juci.desktop"
         DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications")
 endif()
+
+if(ENABLE_TESTING)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_definitions(-DBOOST_LOG_DYN_LINK)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -Wall -Wextra -Wno-unused-parameter -Wno-reorder")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto -DJUCI_TESTS_PATH=\\\"${CMAKE_CURRENT_SOURCE_DIR}\\\"")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DJUCI_TESTS_PATH=\\\"${CMAKE_CURRENT_SOURCE_DIR}\\\"")
 
 if(APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -undefined dynamic_lookup")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,12 +1,7 @@
 add_definitions(-DBOOST_LOG_DYN_LINK)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -Wall -Wextra -Wno-unused-parameter -Wno-reorder")
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DJUCI_TESTS_PATH=\\\"${CMAKE_CURRENT_SOURCE_DIR}\\\" -Wl,--unresolved-symbols=ignore-in-object-files")
-else()
-  message(WARNING "testing only supported for g++")
-  return()
-endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto -DJUCI_TESTS_PATH=\\\"${CMAKE_CURRENT_SOURCE_DIR}\\\"")
 
 if(APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -undefined dynamic_lookup")
@@ -36,18 +31,27 @@ set(global_libraries
   ${Boost_LIBRARIES}
 )
 
+set(stub_sources
+    stubs/config.cc
+    stubs/dialogs.cc
+    stubs/dispatcher.cc
+    stubs/info.cc
+    stubs/terminal.cc
+)
+
 include_directories(${global_includes})
+
+add_library(stubs_library ${stub_sources})
 
 add_executable(cmake_test cmake_test.cc
                ../src/filesystem.cc ../src/cmake.cc ../src/project_build.cc)
-target_link_libraries(cmake_test ${global_libraries})
+target_link_libraries(cmake_test ${global_libraries} stubs_library)
 add_test(cmake_test cmake_test)
 
 #Added for example only, and requires display server to work
 #However, it is possible to use the Broadway backend if the test is run in a pure terminal environment:
 #broadwayd&
 #make test
-add_executable(example_test example_test.cc
-               stubs/dispatcher.cc stubs/terminal.cc stubs/info.cc)
-target_link_libraries(example_test ${global_libraries})
+add_executable(example_test example_test.cc)
+target_link_libraries(example_test ${global_libraries} stubs_library)
 add_test(example_test example_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,53 @@
+add_definitions(-DBOOST_LOG_DYN_LINK)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -Wall -Wextra -Wno-unused-parameter -Wno-reorder")
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DJUCI_TESTS_PATH=\\\"${CMAKE_CURRENT_SOURCE_DIR}\\\" -Wl,--unresolved-symbols=ignore-in-object-files")
+else()
+  message(WARNING "testing only supported for g++")
+  return()
+endif()
+
+if(APPLE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -undefined dynamic_lookup")
+  link_directories(/usr/local/lib /usr/local/opt/gettext/lib)
+  include_directories(/usr/local/opt/gettext/include)
+  set(CMAKE_MACOSX_RPATH 1)
+  set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig")
+endif()
+
+find_package(Boost 1.54 COMPONENTS regex system filesystem REQUIRED)
+set(LIBCLANGMM_INCLUDE_DIR ../libclangmm/src)
+
+include(FindPkgConfig)
+pkg_check_modules(GTKMM gtkmm-3.0 REQUIRED)
+
+set(global_includes
+   ${Boost_INCLUDE_DIRS}
+   ${GTKMM_INCLUDE_DIRS}
+   ${GTKSVMM_INCLUDE_DIRS}
+   ../src
+   ../tiny-process-library
+)
+
+set(global_libraries
+  ${GTKMM_LIBRARIES}
+  ${GTKSVMM_LIBRARIES}
+  ${Boost_LIBRARIES}
+)
+
+include_directories(${global_includes})
+
+add_executable(cmake_test cmake_test.cc
+               ../src/filesystem.cc ../src/cmake.cc ../src/project_build.cc)
+target_link_libraries(cmake_test ${global_libraries})
+add_test(cmake_test cmake_test)
+
+#Added for example only, and requires display server to work
+#However, it is possible to use the Broadway backend if the test is run in a pure terminal environment:
+#broadwayd&
+#make test
+add_executable(example_test example_test.cc
+               stubs/dispatcher.cc stubs/terminal.cc stubs/info.cc)
+target_link_libraries(example_test ${global_libraries})
+add_test(example_test example_test)

--- a/tests/cmake_test.cc
+++ b/tests/cmake_test.cc
@@ -4,9 +4,11 @@
 #include <boost/filesystem.hpp>
 
 int main() {
-  CMake cmake(JUCI_TESTS_PATH);
+  auto tests_path=boost::filesystem::canonical(JUCI_TESTS_PATH);
   
-  g_assert(cmake.project_path.filename()=="jucipp");
+  CMake cmake(tests_path);
+  
+  g_assert(cmake.project_path==boost::filesystem::canonical(tests_path/".."));
   
   auto functions_parameters=cmake.get_functions_parameters("project");
   g_assert(functions_parameters.at(0).second.at(0)=="juci");

--- a/tests/cmake_test.cc
+++ b/tests/cmake_test.cc
@@ -13,8 +13,8 @@ int main() {
   auto functions_parameters=cmake.get_functions_parameters("project");
   g_assert(functions_parameters.at(0).second.at(0)=="juci");
   
-  g_assert(cmake.get_executable(boost::filesystem::path(JUCI_TESTS_PATH)/"cmake_test.cc").filename()=="cmake_test");
+  g_assert(cmake.get_executable(tests_path/"cmake_test.cc").filename()=="cmake_test");
   
-  auto build=Project::Build::create(JUCI_TESTS_PATH);
+  auto build=Project::Build::create(tests_path);
   g_assert(dynamic_cast<Project::CMakeBuild*>(build.get()));
 }

--- a/tests/cmake_test.cc
+++ b/tests/cmake_test.cc
@@ -1,14 +1,16 @@
 #include <glib.h>
 #include "cmake.h"
 #include "project_build.h"
+#include "config.h"
 #include <boost/filesystem.hpp>
 
 int main() {
   auto tests_path=boost::filesystem::canonical(JUCI_TESTS_PATH);
+  auto project_path=boost::filesystem::canonical(tests_path/"..");
   
   CMake cmake(tests_path);
   
-  g_assert(cmake.project_path==boost::filesystem::canonical(tests_path/".."));
+  g_assert(cmake.project_path==project_path);
   
   auto functions_parameters=cmake.get_functions_parameters("project");
   g_assert(functions_parameters.at(0).second.at(0)=="juci");
@@ -17,4 +19,21 @@ int main() {
   
   auto build=Project::Build::create(tests_path);
   g_assert(dynamic_cast<Project::CMakeBuild*>(build.get()));
+  
+  build=Project::Build::create(tests_path/"stubs");
+  g_assert(dynamic_cast<Project::CMakeBuild*>(build.get()));
+  g_assert(build->project_path==project_path);
+  
+  Config::get().project.default_build_path="./build";
+  g_assert(build->get_default_path()==project_path/"./build");
+  
+  Config::get().project.debug_build_path="<default_build_path>/debug";
+  g_assert(build->get_debug_path()==project_path/"./build/debug");
+  
+  auto project_path_filename=project_path.filename();
+  Config::get().project.debug_build_path="../debug_<project_directory_name>";
+  g_assert(build->get_debug_path()==project_path/("../debug_"+project_path_filename.string()));
+  
+  Config::get().project.default_build_path="../build_<project_directory_name>";
+  g_assert(build->get_default_path()==project_path/("../build_"+project_path_filename.string()));
 }

--- a/tests/cmake_test.cc
+++ b/tests/cmake_test.cc
@@ -1,0 +1,18 @@
+#include <glib.h>
+#include "cmake.h"
+#include "project_build.h"
+#include <boost/filesystem.hpp>
+
+int main() {
+  CMake cmake(JUCI_TESTS_PATH);
+  
+  g_assert(cmake.project_path.filename()=="jucipp");
+  
+  auto functions_parameters=cmake.get_functions_parameters("project");
+  g_assert(functions_parameters.at(0).second.at(0)=="juci");
+  
+  g_assert(cmake.get_executable(boost::filesystem::path(JUCI_TESTS_PATH)/"cmake_test.cc").filename()=="cmake_test");
+  
+  auto build=Project::Build::create(JUCI_TESTS_PATH);
+  g_assert(dynamic_cast<Project::CMakeBuild*>(build.get()));
+}

--- a/tests/example_test.cc
+++ b/tests/example_test.cc
@@ -1,0 +1,19 @@
+#include "terminal.h"
+#include "info.h"
+#include <gtkmm.h>
+
+//In case one has to test functions that include Terminal::print or Info::print
+//Requires display server to work
+//However, it is possible to use the Broadway backend if the test is run in a pure terminal environment
+//One also has to include the source stubs/dispatcher.cc in CMakeLists.txt for at least Terminal
+
+//To run the test using broadway backend:
+//broadwayd&
+//make test
+
+int main() {
+  auto app=Gtk::Application::create();
+  Terminal::get().print("some message");
+  Info::get().print("some message");
+  g_assert(true);
+}

--- a/tests/example_test.cc
+++ b/tests/example_test.cc
@@ -4,10 +4,7 @@
 
 //In case one has to test functions that include Terminal::print or Info::print
 //Requires display server to work
-//However, it is possible to use the Broadway backend if the test is run in a pure terminal environment
-//One also has to include the source stubs/dispatcher.cc in CMakeLists.txt for at least Terminal
-
-//To run the test using broadway backend:
+//However, it is possible to use the Broadway backend if the test is run in a pure terminal environment:
 //broadwayd&
 //make test
 

--- a/tests/stubs/config.cc
+++ b/tests/stubs/config.cc
@@ -1,0 +1,3 @@
+#include "config.h"
+
+Config::Config() {}

--- a/tests/stubs/dialogs.cc
+++ b/tests/stubs/dialogs.cc
@@ -1,0 +1,7 @@
+#include "dialogs.h"
+
+Dialog::Message::Message(const std::string &text): Gtk::MessageDialog(text, false, Gtk::MessageType::MESSAGE_INFO, Gtk::ButtonsType::BUTTONS_NONE, true) {}
+
+bool Dialog::Message::on_delete_event(GdkEventAny *event) {
+  return true;
+}

--- a/tests/stubs/dispatcher.cc
+++ b/tests/stubs/dispatcher.cc
@@ -1,0 +1,5 @@
+#include "dispatcher.h"
+
+Dispatcher::Dispatcher() {}
+
+Dispatcher::~Dispatcher() {}

--- a/tests/stubs/info.cc
+++ b/tests/stubs/info.cc
@@ -1,0 +1,5 @@
+#include "info.h"
+
+Info::Info() {}
+
+void Info::print(const std::string &text) {}

--- a/tests/stubs/terminal.cc
+++ b/tests/stubs/terminal.cc
@@ -1,0 +1,11 @@
+#include "terminal.h"
+
+Terminal::Terminal() {}
+
+bool Terminal::on_motion_notify_event(GdkEventMotion* motion_event) {return false;}
+bool Terminal::on_button_press_event(GdkEventButton* button_event) {return false;}
+bool Terminal::on_key_press_event(GdkEventKey *event) {return false;}
+
+size_t Terminal::print(const std::string &message, bool bold) {
+  return 0;
+}

--- a/tests/stubs/terminal.cc
+++ b/tests/stubs/terminal.cc
@@ -6,6 +6,10 @@ bool Terminal::on_motion_notify_event(GdkEventMotion* motion_event) {return fals
 bool Terminal::on_button_press_event(GdkEventButton* button_event) {return false;}
 bool Terminal::on_key_press_event(GdkEventKey *event) {return false;}
 
+int Terminal::process(const std::string &command, const boost::filesystem::path &path, bool use_pipes) {
+  return 0;
+}
+
 size_t Terminal::print(const std::string &message, bool bold) {
   return 0;
 }


### PR DESCRIPTION
To enable testing ~~(only works with g++, clang did not support the needed linking options)~~:
```sh
cmake -DENABLE_TESTING=1 ..
make
make test
```

If you are on a terminal only environment without a display server, like Travis CI:
```sh
broadwayd&
make test
```