### PR TITLE
Added LLVM version 3.8.0 installed by brew in OS X

### DIFF
--- a/cmake_modules/FindLibClang.cmake
+++ b/cmake_modules/FindLibClang.cmake
@@ -16,6 +16,7 @@
 # most recent versions come first
 set(LIBCLANG_KNOWN_LLVM_VERSIONS 3.9
   3.8.1
+  3.8.0
   3.8
   3.7.1
   3.7


### PR DESCRIPTION
I needed to add version 3.8.0 in OS X cause brew installed libclang in /usr/local/Cellar/llvm/3.8.0/lib/libclang.dylib

I did just followed the instruction provided on how to install dependencies in OS X and did not change the directory or version of llvm or where should be installed.
