### PR TITLE
GUI changes in preparation for additional debug information: terminal…

### DIFF
--- a/src/window.h
+++ b/src/window.h
@@ -17,10 +17,6 @@ protected:
   bool on_delete_event(GdkEventAny *event) override;
 
 private:
-  Gtk::VPaned vpaned;
-  Gtk::Paned directory_and_notebook_panes;
-  Gtk::VBox notebook_vbox;
-  Gtk::ScrolledWindow terminal_scrolled_window;
   Gtk::AboutDialog about;
   
   Glib::RefPtr<Gtk::CssProvider> css_provider;


### PR DESCRIPTION
… is now directly below notebook

@zalox ready for merge if you agree on the gui changes, and after you have tested the changes. 

The result is shown below, and the red circle shows where additional debug info like watchpoints and current frame variables will be positioned when its implemented:
![image](https://cloud.githubusercontent.com/assets/5269318/17052536/32e0ac00-4ffe-11e6-9e1d-f222b5b99727.png)
