### PR TITLE
added git status command to menu

### DIFF
--- a/src/menu.cc
+++ b/src/menu.cc
@@ -132,6 +132,10 @@ Menu::Menu() {
         <submenu>
           <attribute name='label' translatable='yes'>_Git</attribute>
           <item>
+            <attribute name='label' translatable='yes'>_Status</attribute>
+            <attribute name='action'>app.source_git_status</attribute>
+          </item>
+          <item>
             <attribute name='label' translatable='yes'>_Go _to _Next _Diff</attribute>
             <attribute name='action'>app.source_git_next_diff</attribute>
           </item>

--- a/src/window.cc
+++ b/src/window.cc
@@ -391,6 +391,15 @@ void Window::set_menu_actions() {
       view->goto_next_spellcheck_error();
   });
   
+  menu.add_action("source_git_status", [this]() {    
+    Project::current=Project::create();
+
+    //we want to save changes before getting the status, even though we are technically not compiling or running
+    if(Config::get().project.save_on_compile_or_run)
+      Project::save_files(Project::current->build->project_path);
+
+    Terminal::get().async_process("git status", Project::current->build->project_path);
+  });
   menu.add_action("source_git_next_diff", [this]() {
     if(auto view=Notebook::get().get_current_view())
       view->git_goto_next_diff();


### PR DESCRIPTION
Added the menu entry Source->Git->Status. It saves unsaved files if `save_on_compile_or_run` is true and it calls `git status` in the project directory.
The output of git status is printed to the terminal. It may need to be made prettier.
The shortcut (probably `CTRL+G+S`) is missing, couldn't figure out how to do it.