### PR TITLE
Fixes segmentation fault when using ctags on very long lines

### DIFF
--- a/src/ctags.cc
+++ b/src/ctags.cc
@@ -146,6 +146,8 @@ std::vector<Ctags::Location> Ctags::get_locations(const boost::filesystem::path 
   long best_score=LONG_MIN;
   std::vector<Location> best_locations;
   while(std::getline(*result.second, line)) {
+    if(line.size()>2048)
+      continue;
     auto location=Ctags::get_location(line, false);
     if(!location.scope.empty()) {
       if(location.scope+"::"+location.symbol!=name)


### PR DESCRIPTION
A segmentation fault occurs when `Ctags::get_location` gets a large line. 

I don't know whether this is normal behaviour, but when juCi++ fell back to ctags it parsed the `./docs` directory as well. A html file had a line of > 40 000 chars, resulting in a failure by the regex library.