### PR TITLE
Corrected install instructions for OS X

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -120,7 +120,7 @@ sudo make install
 Install dependencies:
 ```sh
 brew install --with-clang --with-lldb llvm
-brew install cmake pkg-config boost homebrew/x11/gtksourceviewmm3 aspell clang-format libgit2 ctags
+brew install cmake pkg-config boost gtksourceviewmm3 aspell clang-format libgit2 ctags
 ```
 
 Get juCi++ source, compile and install:


### PR DESCRIPTION
gtksourceviewmm3 is now properly part of homebrew and can be installed directly instead of using homebrew/x11/gtksourceviewmm3.