### PR TITLE
Show file path in the info bar at the bottom

### DIFF
--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -178,6 +178,10 @@ void Notebook::open(const boost::filesystem::path &file_path, size_t notebook_in
     if(get_current_view()==view)
       info.set_text(" "+info_text);
   };
+  source_views.back()->on_update_path_label=[this](Source::View* view, const std::string &path_label_text) {
+    if(get_current_view()==view)
+      path_label.set_text(" "+path_label_text+" ");
+  };
   
   scrolled_windows.emplace_back(new Gtk::ScrolledWindow());
   hboxes.emplace_back(new Gtk::HBox());

--- a/src/notebook.h
+++ b/src/notebook.h
@@ -44,6 +44,7 @@ public:
 
   Gtk::Label info;
   Gtk::Label status;
+  Gtk::Label path_label;
   
   std::function<void(Source::View*)> on_change_page;
   std::function<void(Source::View*)> on_close_page;

--- a/src/source.cc
+++ b/src/source.cc
@@ -863,6 +863,11 @@ void Source::View::set_info(const std::string &info) {
     on_update_info(this, positions+" "+info);
 }
 
+void Source::View::set_path_label(const std::string &path_label){
+  if(on_update_path_label)
+    on_update_path_label(this, path_label);
+}
+
 std::string Source::View::get_line(const Gtk::TextIter &iter) {
   auto line_start_it = get_buffer()->get_iter_at_line(iter.get_line());
   auto line_end_it = get_iter_at_line_end(iter.get_line());

--- a/src/source.h
+++ b/src/source.h
@@ -86,8 +86,10 @@ namespace Source {
     
     std::function<void(View* view, const std::string &status_text)> on_update_status;
     std::function<void(View* view, const std::string &info_text)> on_update_info;
+    std::function<void(View* view, const std::string &path_label_text)> on_update_path_label;
     void set_status(const std::string &status);
     void set_info(const std::string &info);
+    void set_path_label(const std::string &path_label);
     std::string status;
     std::string info;
     

--- a/src/window.cc
+++ b/src/window.cc
@@ -56,6 +56,7 @@ Window::Window() {
   
   auto info_and_status_hbox=Gtk::manage(new Gtk::HBox());
   info_and_status_hbox->pack_start(Notebook::get().info, Gtk::PACK_SHRINK);
+  info_and_status_hbox->pack_start(Notebook::get().path_label, Gtk::PACK_SHRINK);
   info_and_status_hbox->set_center_widget(Project::debug_status_label());
   info_and_status_hbox->pack_end(Notebook::get().status, Gtk::PACK_SHRINK);
   
@@ -124,6 +125,7 @@ Window::Window() {
     
     view->set_status(view->status);
     view->set_info(view->info);
+    view->set_path_label(view->file_path.generic_string());
     
 #ifdef JUCI_ENABLE_DEBUG
     if(Project::debugging)


### PR DESCRIPTION
I haven't created functionality to disable this from the configuration, so this should probably go on a ToDo list...

I added this because I think it's helpful to know which folder I'm working in. I have jucipp cloned 4 times on my drive, one that's just the standard cppit/jucipp clone and 3 working copies (partially from my fork) and it isn't immediately apparant which one I'm working on, unless I go into the "open folder" dialog or search the files for changes I've made.

The path it shows is always the one the cursor is currently in, same as the line-column indicator next to it. If I've understood your code correctly, the path label should only be updated when the view is changed, but I'm not sure, please look over it if possible :)

This is what it looks like:
![file_path_cropped](https://cloud.githubusercontent.com/assets/3718129/18245632/a0bf8350-7366-11e6-8b85-d075babe928d.png)

Edit:
Tested with split mode and in debug mode with a very small window size. The debug status will be pushed off-center by this, but it remains readable. And split mode works just as intended, the path of the file which has the cursor is shown.