### PR TITLE
Reload file

### DIFF
--- a/src/menu.cc
+++ b/src/menu.cc
@@ -63,6 +63,12 @@ Menu::Menu() {
       </section>
       <section>
         <item>
+          <attribute name='label' translatable='yes'>_Reload _File</attribute>
+          <attribute name='action'>app.reload_file</attribute>
+        </item>
+      </section>
+      <section>
+        <item>
           <attribute name='label' translatable='yes'>_Save</attribute>
           <attribute name='action'>app.save</attribute>
         </item>

--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -128,6 +128,38 @@ std::vector<Source::View*> &Notebook::get_views() {
   return source_views;
 }
 
+void Notebook::reload(const boost::filesystem::path &file_path, size_t notebook_index) {
+  if(boost::filesystem::exists(file_path)) {
+    std::ifstream can_read(file_path.string());
+    if(!can_read) {
+      Terminal::get().print("Error: could not open "+file_path.string()+"\n", true);
+      return;
+    }
+    can_read.close();
+  }
+  
+  auto last_view=get_current_view();
+  int offset = last_view->get_buffer()->get_insert()->get_iter().get_offset();
+  int line = last_view->get_buffer()->get_insert()->get_iter().get_line();
+
+  auto language=Source::guess_language(file_path);
+  last_view->get_buffer()->erase(last_view->get_buffer()->begin(), last_view->get_buffer()->end());
+  last_view->get_source_buffer()->begin_not_undoable_action();
+  if(language) {
+    if(filesystem::read_non_utf8(file_path, last_view->get_buffer())==-1)
+      Terminal::get().print("Warning: "+file_path.string()+" is not a valid UTF-8 file. Saving might corrupt the file.\n");
+  }
+  else {
+    if(filesystem::read(file_path, last_view->get_buffer())==-1)
+      Terminal::get().print("Error: "+file_path.string()+" is not a valid UTF-8 file.\n", true);
+  }
+  
+  last_view->get_source_buffer()->end_not_undoable_action();
+
+  last_view->place_cursor_at_line_offset(line, offset);
+  last_view->get_buffer()->set_modified(true);
+}
+
 void Notebook::open(const boost::filesystem::path &file_path, size_t notebook_index) {
   if(notebook_index==1 && !split)
     toggle_split();

--- a/src/notebook.h
+++ b/src/notebook.h
@@ -31,6 +31,7 @@ public:
   std::vector<Source::View*> &get_views();
   
   void open(const boost::filesystem::path &file_path, size_t notebook_index=-1);
+  void reload(const boost::filesystem::path &file_path, size_t notebook_index=-1);
   void configure(size_t index);
   bool save(size_t index);
   bool save_current();

--- a/src/window.cc
+++ b/src/window.cc
@@ -319,6 +319,13 @@ void Window::set_menu_actions() {
       Directories::get().open(path);
   });
   
+  menu.add_action("reload_file", [this]() {
+    auto path = Notebook::get().get_current_view()->file_path;
+    std::cout<<"Path: "<<path<<std::endl;
+    Notebook::get().close_current();
+    Notebook::get().open(path);
+  });
+  
   menu.add_action("save", [this]() {
     if(auto view=Notebook::get().get_current_view()) {
       if(Notebook::get().save_current()) {

--- a/src/window.cc
+++ b/src/window.cc
@@ -321,8 +321,7 @@ void Window::set_menu_actions() {
   
   menu.add_action("reload_file", [this]() {
     auto path = Notebook::get().get_current_view()->file_path;
-    Notebook::get().close_current();
-    Notebook::get().open(path);
+    Notebook::get().reload(path);
   });
   
   menu.add_action("save", [this]() {

--- a/src/window.cc
+++ b/src/window.cc
@@ -321,7 +321,6 @@ void Window::set_menu_actions() {
   
   menu.add_action("reload_file", [this]() {
     auto path = Notebook::get().get_current_view()->file_path;
-    std::cout<<"Path: "<<path<<std::endl;
     Notebook::get().close_current();
     Notebook::get().open(path);
   });


### PR DESCRIPTION
Adds a menu option to reload the current file.
Normally when a file is changed from outside of juCi++, it first has to be closed completely and then re-opened in order to work with these changes.

In case of a race while using this PR (a file was changed externally and juCi++ has unsaved changes), upon clicking "Reload File" in the menu, the function will always be executed, but the user is asked if they want to save the current file before it's opened. There's no merging and no backups, either the file on the drive is overwritten or the changes within the editor are overwritten.

To fix this, it would make sense to add an extra warning beforehand, or, instead of an overwriting save, open the "Save File As" prompt, to give the user the option to save his current changes to a separate file and manually merge them afterwards.

I don't know how to do that, so it's not in this pull request.

This pull request addresses this issue I opened earlier: https://github.com/cppit/jucipp/issues/285

I'm going to try to find out how to solve the race-condition, but I'd like your input on that.