### PR TITLE
use canonical file path in Notebook::open to avoid duplicated parsing with soft-linked files.

### DIFF
--- a/src/notebook.cc
+++ b/src/notebook.cc
@@ -141,6 +141,8 @@ void Notebook::open(const boost::filesystem::path &file_path, size_t notebook_in
       return;
     }
   }
+
+  boost::filesystem::path canonical_path = file_path;
   
   if(boost::filesystem::exists(file_path)) {
     std::ifstream can_read(file_path.string());
@@ -149,15 +151,17 @@ void Notebook::open(const boost::filesystem::path &file_path, size_t notebook_in
       return;
     }
     can_read.close();
+
+    canonical_path = boost::filesystem::canonical(file_path);
   }
   
   auto last_view=get_current_view();
   
-  auto language=Source::guess_language(file_path);
+  auto language=Source::guess_language(canonical_path);
   if(language && (language->get_id()=="chdr" || language->get_id()=="cpphdr" || language->get_id()=="c" || language->get_id()=="cpp" || language->get_id()=="objc"))
-    source_views.emplace_back(new Source::ClangView(file_path, language));
+    source_views.emplace_back(new Source::ClangView(canonical_path, language));
   else
-    source_views.emplace_back(new Source::GenericView(file_path, language));
+    source_views.emplace_back(new Source::GenericView(canonical_path, language));
   
   source_views.back()->scroll_to_cursor_delayed=[this](Source::View* view, bool center, bool show_tooltips) {
     while(Gtk::Main::events_pending())


### PR DESCRIPTION
If there are soft-linked files in the project, the same file is treated as two different files and is parsed mulitple times, and duplicated symbols will show up when doing symbol lookups, like: doing "Go to Method", "Go to Usage".
Using canonical file path in Notebook::open fix the problem.