### PR TITLE
typo and mwindows flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ pkg_check_modules(LIBGIT2 libgit2 REQUIRED)
 
 if(MSYS)
   set(global_libraries winpthread)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mwindows")
 endif()
 set(global_libraries ${global_libraries}
   ${GTKMM_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ pkg_check_modules(LIBGIT2 libgit2 REQUIRED)
 
 if(MSYS)
   set(global_libraries winpthread)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mwindows")
 endif()
 set(global_libraries ${global_libraries}
   ${GTKMM_LIBRARIES}

--- a/docs/install.md
+++ b/docs/install.md
@@ -133,7 +133,7 @@ make
 make install
 ```
 
-##Windows with MSYS2 (https://msys2.github.io/)
+## Windows with MSYS2 (https://msys2.github.io/)
 **See https://github.com/cppit/jucipp/issues/190 for details on adding debug support in MSYS2**
 
 Install dependencies (replace `x86_64` with `i686` for 32-bit MSYS2 installs):


### PR DESCRIPTION
Fix 1: Fixed typo in the install instructions.

Fix 2: Set -mwindows flag as default on Windows. At the moment opening the application spawns a terminal in the background.  [-mwindows](https://gcc.gnu.org/onlinedocs/gcc/x86-Windows-Options.html)