### PR TITLE
Add right margin line in sourceview

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 2.8.8)
 
 project(juci)
-set(JUCI_VERSION "1.3.1")
+set(JUCI_VERSION "1.3.0.1")
 
 set(CPACK_PACKAGE_NAME "jucipp")
 set(CPACK_PACKAGE_CONTACT "Ole Christian Eidheim <eidheim@gmail.com>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 2.8.8)
 
 project(juci)
-set(JUCI_VERSION "1.3.0")
+set(JUCI_VERSION "1.3.1")
 
 set(CPACK_PACKAGE_NAME "jucipp")
 set(CPACK_PACKAGE_CONTACT "Ole Christian Eidheim <eidheim@gmail.com>")

--- a/src/config.cc
+++ b/src/config.cc
@@ -161,6 +161,8 @@ void Config::read(const boost::property_tree::ptree &cfg) {
   source.map_font_size = source_json.get<std::string>("map_font_size");
   source.show_git_diff = source_json.get<bool>("show_git_diff");
   source.show_background_pattern = source_json.get<bool>("show_background_pattern");
+  source.show_right_margin = source_json.get<bool>("show_right_margin");
+  source.right_margin_position = source_json.get<unsigned>("right_margin_position");
   source.spellcheck_language = source_json.get<std::string>("spellcheck_language");
   source.default_tab_char = source_json.get<char>("default_tab_char");
   source.default_tab_size = source_json.get<unsigned>("default_tab_size");
@@ -174,7 +176,7 @@ void Config::read(const boost::property_tree::ptree &cfg) {
       source.clang_types[std::stoi(i.first)] = i.second.get_value<std::string>();
     }
     catch(const std::exception &) {}
-  }  
+  }
   source.clang_format_style = source_json.get<std::string>("clang_format_style");
   source.clang_usages_threads = static_cast<unsigned>(source_json.get<int>("clang_usages_threads"));
   auto pt_doc_search=cfg.get_child("documentation_searches");

--- a/src/config.h
+++ b/src/config.h
@@ -78,6 +78,8 @@ public:
     std::string map_font_size;
     bool show_git_diff;
     bool show_background_pattern;
+    bool show_right_margin;
+    unsigned right_margin_position;
     
     bool auto_tab_char_and_size;
     char default_tab_char;

--- a/src/files.h
+++ b/src/files.h
@@ -50,6 +50,8 @@ R"RAW(
         "map_font_size": "1",
         "show_git_diff": true,
         "show_background_pattern": true,
+        "show_right_margin": false,
+        "right_margin_position": 80,
         "spellcheck_language_comment": "Use \"\" to set language from your locale settings",
         "spellcheck_language": "en_US",
         "auto_tab_char_and_size_comment": "Use false to always use default tab char and size",

--- a/src/source.cc
+++ b/src/source.cc
@@ -783,6 +783,8 @@ void Source::View::configure() {
     gtk_source_view_set_background_pattern(this->gobj(), GTK_SOURCE_BACKGROUND_PATTERN_TYPE_GRID);
   else
     gtk_source_view_set_background_pattern(this->gobj(), GTK_SOURCE_BACKGROUND_PATTERN_TYPE_NONE);
+  property_show_right_margin() = Config::get().source.show_right_margin;
+  property_right_margin_position() = Config::get().source.right_margin_position;
   
   //Create tags for diagnostic warnings and errors:
   auto scheme = get_source_buffer()->get_style_scheme();


### PR DESCRIPTION
Add right margin line in sourceview. The margin can be activated and configured in the source section of the config file.