### PR TITLE
Adds support for OpenCL source-files

### DIFF
--- a/src/compile_commands.cc
+++ b/src/compile_commands.cc
@@ -147,6 +147,14 @@ std::vector<std::string> CompileCommands::get_arguments(const boost::filesystem:
     arguments.emplace_back("cuda_runtime.h");
   }
   
+  if(extension==".cl") {
+    arguments.emplace_back("-xcl");
+    arguments.emplace_back("-cl-std=CL2.0");
+    arguments.emplace_back("-Xclang");
+    arguments.emplace_back("-finclude-default-header");
+    arguments.emplace_back("-Wno-gcc-compat");
+  }
+  
   if(!build_path.empty()) {
     arguments.emplace_back("-working-directory");
     arguments.emplace_back(build_path.string());

--- a/src/source.cc
+++ b/src/source.cc
@@ -70,6 +70,9 @@ Glib::RefPtr<Gsv::Language> Source::guess_language(const boost::filesystem::path
     else
       language=language_manager->get_language("cpp");
   }
+  else if(language->get_id()=="opencl") {
+    language = language_manager->get_language("cpp");
+  }
   return language;
 }
 

--- a/src/usages_clang.cc
+++ b/src/usages_clang.cc
@@ -561,7 +561,8 @@ bool Usages::Clang::is_source(const boost::filesystem::path &path) {
   auto ext = path.extension();
   if(ext == ".c" || // c sources
      ext == ".cpp" || ext == ".cxx" || ext == ".cc" || ext == ".C" || ext == ".c++" || // c++ sources
-     ext == ".cu") // CUDA sources
+     ext == ".cu" || // CUDA sources
+     ext == ".cl") // OpenCL sources
     return true;
   else
     return false;


### PR DESCRIPTION
Adds support for OpenCL similar to the support for CUDA added in https://github.com/cppit/jucipp/issues/357.

Support includes:
- auto completion for OpenCL C 2.0 standard-library functions
- documentation tooltips for OpenCL standard-library functions (as long as documented in the [header](https://github.com/llvm-mirror/clang/blob/master/lib/Headers/opencl-c.h))