### PR TITLE
add includes necessary to compile

### DIFF
--- a/src/dispatcher.h
+++ b/src/dispatcher.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <gtkmm.h>
 #include <mutex>
+#include <functional>
 #include <list>
 
 class Dispatcher {

--- a/src/menu.h
+++ b/src/menu.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <unordered_map>
+#include <functional>
 #include <gtkmm.h>
 
 class Menu {

--- a/src/selection_dialog.h
+++ b/src/selection_dialog.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "gtkmm.h"
 #include <unordered_map>
+#include <functional>
 
 class SelectionDialogBase {
   class ListViewText : public Gtk::TreeView {

--- a/src/tooltips.h
+++ b/src/tooltips.h
@@ -2,6 +2,7 @@
 #include "gtkmm.h"
 #include <string>
 #include <list>
+#include <functional>
 
 class Tooltip {
 public:


### PR DESCRIPTION
On my system, it was necessary to add these includes in order to compile. Without this, it doesn't recognize `std::function<>`.

My system is ubuntu 16.04, cmake 3.9.0, g++ 5.4.0.
